### PR TITLE
Add readme to pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ documentation = "https://vectorinstitute.github.io/cyclops/"
 packages = [
     { include = "cyclops" },
 ]
+readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "3.9.7"


### PR DESCRIPTION
# Fix

## Short Description
Fixes issue with PyPI package release since it wasn't able to find the readme content (long_description).