### PR TITLE
Add support for querying in batches using dask

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ use cases include:
 
 ## 🐣 Getting Started
 
-### Installing the cyclops package using pip
+### Installing cyclops using pip
 
 ```bash
 python3 -m pip install pycyclops

--- a/cyclops/models/constants.py
+++ b/cyclops/models/constants.py
@@ -1,4 +1,5 @@
 """Model library constants."""
+
 import os
 
 from cyclops.utils.file import join

--- a/cyclops/query/interface.py
+++ b/cyclops/query/interface.py
@@ -2,8 +2,9 @@
 
 import logging
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Generator, Optional, Union
+from typing import Callable, Dict, Optional, Union
 
+import dask.dataframe as dd
 import pandas as pd
 
 from cyclops.query.orm import Database
@@ -42,24 +43,40 @@ class QueryInterface:
     def run(
         self,
         limit: Optional[int] = None,
-    ) -> pd.DataFrame:
+        backend: Optional[str] = "pandas",
+        index_col: Optional[str] = None,
+        n_partitions: Optional[int] = None,
+    ) -> Union[pd.DataFrame, dd.DataFrame]:
         """Run the query, and fetch data.
 
         Parameters
         ----------
         limit: int, optional
             No. of rows to limit the query return.
+        backend: str, optional
+            Backend computing framework to use, Pandas or Dask.
+        index_col: str, optional
+            Column which becomes the index, and defines the partitioning.
+            Should be a indexed column in the SQL server, and any orderable type.
+        n_partitions: int, optional
+            Number of partitions. Check dask documentation for additional details.
 
         Returns
         -------
-        pandas.DataFrame
+        pandas.DataFrame or dask.DataFrame
             Query result dataframe.
 
         """
-        # Only re-run when new run arguments are given
+        # Only re-run when new run arguments are given.
         if self.data is None or not self._run_args == locals():
             self._run_args = locals()
-            self.data = self.database.run_query(self.query, limit=limit)
+            self.data = self.database.run_query(
+                self.query,
+                limit=limit,
+                backend=backend,
+                index_col=index_col,
+                n_partitions=n_partitions,
+            )
 
         return self.data
 
@@ -79,12 +96,12 @@ class QueryInterface:
             Processed save path for upstream use.
 
         """
-        # If the query was already run
+        # If the query was already run.
         if self.data is not None:
             path = save_dataframe(self.data, path, file_format=file_format)
             return path
 
-        # Save without running
+        # Save without running.
         if file_format == "csv":
             path = self.database.save_query_to_csv(self.query, path)
         elif file_format == "parquet":
@@ -102,70 +119,12 @@ class QueryInterface:
         """
         self.data = None
 
-    def run_in_grouped_batches(
-        self, id_col: str, batch_size: int
-    ) -> Generator[pd.DataFrame, None, None]:
-        """Run the query in batches with complete sets of sample IDs.
-
-        Queries are sorted and grouped such that the rows for a given sample ID are kept
-        together in a single batch.
-
-        Parameters
-        ----------
-        id_col: str
-            Name of the sample ID column by which to batch.
-        batch_size: int
-            Approximate batch size before rearranging based on sample IDs.
-
-        Yields
-        ------
-        pandas.DataFrame
-            A query batch with complete sets of sample IDs.
-
-        """
-        generator = self.database.run_id_batched_query(self.query, id_col, batch_size)
-        while True:
-            try:
-                yield next(generator)
-            except StopIteration:
-                return
-
-    def save_in_grouped_batches(
-        self,
-        dir_path: str,
-        id_col: str,
-        batch_size: int,
-        file_format: str = "parquet",
-    ) -> None:
-        """Save a query in different batches, keeping same sample IDs together.
-
-        Queries are sorted and grouped such that the rows for a given sample ID are kept
-        together in a single batch.
-
-        Parameters
-        ----------
-        query: cyclops.query.util.TableTypes
-            Query to run.
-        dir_path: str
-            Path to directory in which to save the batches.
-        batch_size: int
-            Approximate batch size before rearranging based on sample IDs.
-        id_col: str
-            Name of the sample ID column by which to batch.
-        file_format: str
-            File format of the DataFrame to save.
-
-        """
-        self.database.save_id_batched_query(
-            self.query, dir_path, id_col, batch_size, file_format=file_format
-        )
-
 
 @dataclass
 class QueryInterfaceProcessed:
     """An interface dataclass to wrap queries, and run them with post-processing.
 
-    An similar dataclass to QueryInterface, where custom post-processing
+    A similar dataclass to QueryInterface, where custom post-processing
     functions on the pandas dataframe returned from the query can be run. However,
     this prevents the query from being further used, and hence is declared as
     private attribute.
@@ -195,23 +154,40 @@ class QueryInterfaceProcessed:
     def run(
         self,
         limit: Optional[int] = None,
-    ) -> pd.DataFrame:
+        backend: Optional[str] = "pandas",
+        index_col: Optional[str] = None,
+        n_partitions: Optional[int] = None,
+    ) -> Union[pd.DataFrame, dd.DataFrame]:
         """Run the query, and fetch data.
 
         Parameters
         ----------
         limit: int, optional
             No. of rows to limit the query return.
+        backend: str, optional
+            Backend computing framework to use, Pandas or Dask.
+        index_col: str, optional
+            Column which becomes the index, and defines the partitioning.
+            Should be a indexed column in the SQL server, and any orderable type.
+        n_partitions: int, optional
+            Number of partitions. Check dask documentation for additional details.
 
         Returns
         -------
-        pandas.DataFrame
+        pandas.DataFrame or dask.DataFrame
             Query result dataframe.
 
         """
+        # Only re-run when new run arguments are given.
         if self.data is None or not self._run_args == locals():
             self._run_args = locals()
-            self.data = self.database.run_query(self._query, limit=limit)
+            self.data = self.database.run_query(
+                self._query,
+                limit=limit,
+                backend=backend,
+                index_col=index_col,
+                n_partitions=n_partitions,
+            )
 
             LOGGER.info(
                 "Applying post-processing fn %s to query output",
@@ -240,8 +216,8 @@ class QueryInterfaceProcessed:
         # The query must be run in order to be processed.
         if self.data is None:
             self.run()
-
         path = save_dataframe(self.data, path, file_format=file_format)
+
         return path
 
     def clear_data(self) -> None:

--- a/cyclops/query/interface.py
+++ b/cyclops/query/interface.py
@@ -2,7 +2,7 @@
 
 import logging
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, Literal, Optional, Union
 
 import dask.dataframe as dd
 import pandas as pd
@@ -43,7 +43,7 @@ class QueryInterface:
     def run(
         self,
         limit: Optional[int] = None,
-        backend: Optional[str] = "pandas",
+        backend: Literal["pandas", "dask"] = "pandas",
         index_col: Optional[str] = None,
         n_partitions: Optional[int] = None,
     ) -> Union[pd.DataFrame, dd.DataFrame]:
@@ -51,14 +51,14 @@ class QueryInterface:
 
         Parameters
         ----------
-        limit: int, optional
+        limit
             No. of rows to limit the query return.
-        backend: str, optional
+        backend
             Backend computing framework to use, Pandas or Dask.
-        index_col: str, optional
+        index_col
             Column which becomes the index, and defines the partitioning.
             Should be a indexed column in the SQL server, and any orderable type.
-        n_partitions: int, optional
+        n_partitions
             Number of partitions. Check dask documentation for additional details.
 
         Returns

--- a/cyclops/query/orm.py
+++ b/cyclops/query/orm.py
@@ -4,33 +4,21 @@ import csv
 import logging
 import os
 import socket
-from typing import Generator, List, Optional, Union
+from typing import Optional, Union
 
+import dask.dataframe as dd
 import pandas as pd
 import pyarrow.csv as pv
 import pyarrow.parquet as pq
 from omegaconf import DictConfig
-from sqlalchemy import MetaData, and_, create_engine, func, inspect, select
+from sqlalchemy import MetaData, create_engine, inspect
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql.elements import BinaryExpression, BooleanClauseList
-from sqlalchemy.sql.selectable import Select, Subquery
+from sqlalchemy.sql.selectable import Select
 
-from cyclops.query.util import (
-    DBSchema,
-    DBTable,
-    TableTypes,
-    get_column,
-    table_params_to_type,
-)
-from cyclops.utils.file import (
-    exchange_extension,
-    join,
-    process_dir_save_path,
-    process_file_save_path,
-    save_dataframe,
-)
+from cyclops.query.util import DBSchema, DBTable, TableTypes, table_params_to_type
+from cyclops.utils.file import exchange_extension, process_file_save_path
 from cyclops.utils.log import setup_logging
 from cyclops.utils.profile import time_function
 
@@ -100,6 +88,14 @@ class Database:
 
     def _create_engine(self) -> Engine:
         """Create an engine."""
+        self.conn = _get_db_url(
+            self.config.dbms,
+            self.config.user,
+            self.config.password,
+            self.config.host,
+            self.config.port,
+            self.config.database,
+        )
         engine = create_engine(
             _get_db_url(
                 self.config.dbms,
@@ -143,58 +139,56 @@ class Database:
     @table_params_to_type(Select)
     def run_query(
         self,
-        query: TableTypes,
+        query: Union[TableTypes, str],
         limit: Optional[int] = None,
-    ) -> pd.DataFrame:
+        backend: Optional[str] = "pandas",
+        index_col: Optional[str] = None,
+        n_partitions: Optional[int] = None,
+    ) -> Union[pd.DataFrame, dd.DataFrame]:
         """Run query.
 
         Parameters
         ----------
         query: cyclops.query.util.TableTypes
             Query to run.
-        limit: Optional[int]
+        limit: int, optional
             Limit query result to limit.
+        backend: str, optional
+            Backend computing framework to use, Pandas or Dask.
+        index_col: str, optional
+            Column which becomes the index, and defines the partitioning.
+            Should be a indexed column in the SQL server, and any orderable type.
+        n_partitions: int, optional
+            Number of partitions. Check dask documentation for additional details.
 
         Returns
         -------
-        pd.DataFrame
+        pandas.DataFrame or dask.DataFrame
             Extracted data from query.
 
         """
-        # Limit the results returned
+        if isinstance(query, str) and limit is not None:
+            raise ValueError(
+                "Cannot use limit argument when running raw SQL string query!"
+            )
+        if backend == "pandas" and n_partitions is not None:
+            raise ValueError("Partitions not applicable with Pandas backend, use Dask!")
+        # Limit the results returned.
         if limit is not None:
             query = query.limit(limit)  # type: ignore
 
-        # Run the query and return the results
+        # Run the query and return the results.
         with self.session.connection():
-            data = pd.read_sql_query(query, self.engine)
-
+            if backend == "pandas":
+                data = pd.read_sql_query(query, self.engine, index_col=index_col)
+            elif backend == "dask":
+                data = dd.read_sql_query(
+                    query, self.conn, index_col=index_col, npartitions=n_partitions
+                )
+            else:
+                raise ValueError("Invalid backend, can either be Pandas or Dask!")
         LOGGER.info("Query returned successfully!")
-        return data
 
-    @time_function
-    def run_sql_string(
-        self,
-        query: str,
-    ) -> pd.DataFrame:
-        """Run query from SQL raw SQL string.
-
-        Parameters
-        ----------
-        query: str
-            Raw SQL query string.
-
-        Returns
-        -------
-        pd.DataFrame
-            Extracted data from query.
-
-        """
-        # Run the query and return the results
-        with self.session.connection():
-            data = pd.read_sql_query(query, self.engine)
-
-        LOGGER.info("Query returned successfully!")
         return data
 
     @time_function
@@ -252,166 +246,5 @@ class Database:
         table = pv.read_csv(csv_path)
         os.remove(csv_path)
         pq.write_table(table, path)
+
         return path
-
-    def query_batch_conditions(
-        self,
-        query: TableTypes,
-        id_col: str,
-        batch_size: int,
-    ) -> List[Union[BinaryExpression, BooleanClauseList]]:
-        """Return a list of WHERE conditions to segment a query into batches.
-
-        Batches are created via SQL windowing, based on segmenting the values in a
-        given column, such as an ID column, into intervals.
-
-        Requires a database that supports window functions.
-
-        Parameters
-        ----------
-        column: sqlalchemy.sql.schema.Column
-            The column over which to create the interval ranges and conditions.
-        window_size: int
-            The range of the interval to create.
-
-        Returns
-        -------
-        list of sqlalchemy.sql.elements.BinaryExpression or
-        sqlalchemy.sql.elements.BooleanClauseList
-            The window conditions on which to filter.
-
-        """
-
-        def compute_query_dividers(query, id_col, maximum):
-            # Compute the row count for each unique value
-            col = get_column(query, id_col)
-            table = select(col, func.count(col).label("count")).group_by(col)
-            count_data = self.run_query(table)
-
-            # Check that all values can actually fit into the maximum batch size
-            max_count = count_data["count"].max()
-            if maximum < max_count:
-                raise ValueError(f"Maximum must be at least {max_count}.")
-
-            # Sort and create a cumulative sum of row counts
-            count_data = count_data.sort_values(id_col)
-            count_data["cumsum"] = count_data["count"].cumsum()
-
-            # Create query dividers
-            last_sum = 0
-
-            if len(count_data) == 0:
-                raise ValueError("Query is empty. Cannot return batched results.")
-
-            dividers = [int(count_data[id_col].iloc[0])]
-            for i, cumsum in enumerate(count_data["cumsum"].values[1:]):
-                # If adding the next value will put the sum over the max,
-                # then add another divider on the previous value
-                if cumsum - last_sum > maximum:
-                    dividers.append(int(count_data[id_col].iloc[i]))
-                    last_sum = count_data["cumsum"].iloc[i]
-
-            return dividers
-
-        def range_condition(start_id, end_id):
-            if end_id:
-                return and_(column >= start_id, column < end_id)
-
-            return column >= start_id
-
-        # Create interval dividers
-        dividers = compute_query_dividers(query, id_col, batch_size)
-        # print("dividers", dividers)
-
-        # Create filtering conditions
-        column = get_column(query, id_col)
-        conditions = []
-        while dividers:
-            # Create interval ranges
-            start = dividers.pop(0)
-            if dividers:
-                end = dividers[0]
-            else:
-                end = None
-
-            # Create condition
-            conditions.append(range_condition(start, end))
-
-        return conditions
-
-    @table_params_to_type(Subquery)
-    def run_id_batched_query(
-        self,
-        query: TableTypes,
-        id_col: str,
-        batch_size: int,
-    ) -> Generator[pd.DataFrame, None, None]:
-        """Generate query batches with complete sets of IDs in a batch.
-
-        Queries are sorted and grouped such that the rows for a given sample ID are kept
-        together in a single batch.
-
-        Parameters
-        ----------
-        query: cyclops.query.util.TableTypes
-            Query to run.
-        window_size: int
-            Window size used to batch queries over the ID column.
-        id_col: str
-            Name of the sample ID column by which to batch.
-
-        Yields
-        ------
-        pandas.DataFrame
-            A query batch with complete sets of sample IDs.
-
-        """
-        if "limit" in str(query).lower():
-            raise NotImplementedError(
-                "Currently not supporting batching for queries with a LIMIT."
-            )
-
-        conditions = self.query_batch_conditions(query, id_col, batch_size)
-        sess_query = self.session.query(query)
-
-        # Opportunity for easy multi-processing/parallelization here!
-        for condition in conditions:
-            run = (sess_query.filter(condition)).subquery()
-            yield pd.read_sql_query(run, self.engine)
-
-    @time_function
-    def save_id_batched_query(  # pylint: disable=too-many-arguments
-        self,
-        query: TableTypes,
-        dir_path: str,
-        id_col: str,
-        batch_size: int,
-        file_format: str = "parquet",
-    ) -> None:
-        """Save a query in different batches, keeping same sample IDs together.
-
-        Queries are sorted and grouped such that the rows for a given sample ID are kept
-        together in a single batch.
-
-        Parameters
-        ----------
-        query: cyclops.query.util.TableTypes
-            Query to run.
-        dir_path: str
-            Path to directory in which to save the batches.
-        batch_size: int
-            Approximate batch size before rearranging based on sample IDs.
-        id_col: str
-            Name of the sample ID column by which to batch.
-        file_format: str
-            File format of the DataFrame to save.
-
-        """
-        dir_path = process_dir_save_path(dir_path)
-        generator = self.run_id_batched_query(query, id_col, batch_size)
-        for i, batch in enumerate(generator):
-            save_dataframe(
-                batch,
-                join(dir_path, "batch_" + f"{i:04d}"),
-                file_format=file_format,
-            )

--- a/cyclops/query/orm.py
+++ b/cyclops/query/orm.py
@@ -4,7 +4,7 @@ import csv
 import logging
 import os
 import socket
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import dask.dataframe as dd
 import pandas as pd
@@ -141,7 +141,7 @@ class Database:
         self,
         query: Union[TableTypes, str],
         limit: Optional[int] = None,
-        backend: Optional[str] = "pandas",
+        backend: Literal["pandas", "dask"] = "pandas",
         index_col: Optional[str] = None,
         n_partitions: Optional[int] = None,
     ) -> Union[pd.DataFrame, dd.DataFrame]:
@@ -149,16 +149,16 @@ class Database:
 
         Parameters
         ----------
-        query: cyclops.query.util.TableTypes or str
+        query
             Query to run.
-        limit: int, optional
+        limit
             Limit query result to limit.
-        backend: str, optional
+        backend
             Backend computing framework to use, Pandas or Dask.
-        index_col: str, optional
+        index_col
             Column which becomes the index, and defines the partitioning.
             Should be a indexed column in the SQL server, and any orderable type.
-        n_partitions: int, optional
+        n_partitions
             Number of partitions. Check dask documentation for additional details.
 
         Returns

--- a/cyclops/query/orm.py
+++ b/cyclops/query/orm.py
@@ -149,7 +149,7 @@ class Database:
 
         Parameters
         ----------
-        query: cyclops.query.util.TableTypes
+        query: cyclops.query.util.TableTypes or str
             Query to run.
         limit: int, optional
             Limit query result to limit.

--- a/cyclops/query/orm.py
+++ b/cyclops/query/orm.py
@@ -185,6 +185,7 @@ class Database:
                 data = dd.read_sql_query(
                     query, self.conn, index_col=index_col, npartitions=n_partitions
                 )
+                data = data.reset_index(drop=False)
             else:
                 raise ValueError("Invalid backend, can either be Pandas or Dask!")
         LOGGER.info("Query returned successfully!")

--- a/cyclops/utils/file.py
+++ b/cyclops/utils/file.py
@@ -8,6 +8,7 @@ from typing import Any, Generator, List, Optional, Union
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
+import dask.dataframe as dd
 
 from cyclops.utils.log import setup_logging
 
@@ -182,7 +183,7 @@ def load_dataframe(
     load_path: str,
     file_format: str = "parquet",
     log: bool = True,
-) -> pd.DataFrame:
+) -> Union[pd.DataFrame, dd.DataFrame]:
     """Load file to a pandas.DataFrame or dask.DataFrame object.
 
     Parameters
@@ -196,12 +197,11 @@ def load_dataframe(
 
     Returns
     -------
-    pandas.DataFrame
+    pandas.DataFrame or dask.DataFrame
         Loaded data.
 
     """
     load_path = process_file_save_path(load_path, file_format)
-    print(load_path)
     if log:
         LOGGER.info("Loading DataFrame from %s", load_path)
     if file_format == "parquet":

--- a/cyclops/utils/file.py
+++ b/cyclops/utils/file.py
@@ -3,8 +3,9 @@
 import logging
 import os
 import pickle
-from typing import Any, Generator, List, Optional
+from typing import Any, Generator, List, Optional, Union
 
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 
@@ -127,12 +128,12 @@ def process_dir_save_path(save_path: str, create_dir: bool = True) -> str:
 
 
 def save_dataframe(
-    data: pd.DataFrame,
+    data: Union[pd.DataFrame, dd.DataFrame],
     save_path: str,
     file_format: str = "parquet",
     log: bool = True,
 ) -> str:
-    """Save a pandas.DataFrame object to file.
+    """Save a pandas.DataFrame or dask.DataFrame object to file.
 
     Parameters
     ----------
@@ -151,16 +152,22 @@ def save_dataframe(
         Processed save path for upstream use.
 
     """
-    save_path = process_file_save_path(save_path, file_format)
-
-    if not isinstance(data, pd.DataFrame):
+    if not isinstance(data, (pd.DataFrame, dd.DataFrame)):
         raise ValueError("Input data is not a DataFrame.")
-
+    save_path = process_file_save_path(save_path, file_format)
+    if isinstance(data, dd.DataFrame):
+        save_path, _ = os.path.splitext(save_path)
     if log:
         LOGGER.info("Saving dataframe to %s", save_path)
-
     if file_format == "parquet":
-        data.to_parquet(save_path)
+        if isinstance(data, pd.DataFrame):
+            data.to_parquet(save_path, schema=None)
+        if isinstance(data, dd.DataFrame):
+            data.to_parquet(
+                save_path,
+                schema=None,
+                name_function=lambda x: f"batch-{str(x).zfill(3)}.parquet",
+            )
     elif file_format == "csv":
         data.to_csv(save_path)
     else:
@@ -176,7 +183,7 @@ def load_dataframe(
     file_format: str = "parquet",
     log: bool = True,
 ) -> pd.DataFrame:
-    """Load file to a pandas.DataFrame object.
+    """Load file to a pandas.DataFrame or dask.DataFrame object.
 
     Parameters
     ----------
@@ -194,10 +201,9 @@ def load_dataframe(
 
     """
     load_path = process_file_save_path(load_path, file_format)
-
+    print(load_path)
     if log:
         LOGGER.info("Loading DataFrame from %s", load_path)
-
     if file_format == "parquet":
         data = pd.read_parquet(load_path)
     elif file_format == "csv":
@@ -402,80 +408,6 @@ def yield_dataframes(
 
     for file in files:
         yield load_dataframe(join(dir_path, file), log=log)
-
-
-def concat_consequtive_dataframes(
-    dir_path: str,
-    every_n: int,
-    log: bool = True,
-) -> Generator[pd.DataFrame, None, None]:
-    """Yield DataFrames concatenated from consequtive files in a directory.
-
-    Any non-hidden files in the directory must be loadable as a DataFrame.
-
-    Parameters
-    ----------
-    dir_path: str
-        Directory path of files. Any non-hidden file must be loadable as a DataFrame.
-    every_n: int
-        Concatenate and yield every N consequtive files.
-    log: bool
-        Whether to log the occurence.
-
-    Yields
-    ------
-    pandas.DataFrame
-        Concatenated DataFrame.
-
-    """
-    assert every_n > 1
-
-    datas = []
-    for i, data in enumerate(yield_dataframes(dir_path, log=log)):
-        datas.append(data)
-
-        # Yield full batches
-        if (i + 1) % every_n == 0:
-            yield pd.concat(datas)
-            datas = []
-
-    # Yield if any remaining
-    if len(datas) > 0:
-        yield pd.concat(datas)
-
-
-def save_consequtive_dataframes(
-    prev_dir: str,
-    new_dir: str,
-    every_n: int,
-    log: bool = True,
-) -> None:
-    """Save DataFrames concatenated from consequtive files in a directory.
-
-    Parameters
-    ----------
-    prev_dir: str
-        Directory path of files. Any non-hidden file must be loadable as a DataFrame.
-    new_dir: str
-        Directory in which to save the newly concatenated DataFrames.
-    every_n: int
-        Concatenate and yield every N consequtive files.
-    log: bool
-        Whether to log the occurence.
-
-    """
-    new_dir = process_dir_save_path(new_dir)
-    generator = concat_consequtive_dataframes(prev_dir, every_n, log=log)
-
-    save_count = 0
-    while True:
-        try:
-            save_dataframe(
-                next(generator), join(new_dir, "batch_" + f"{save_count:04d}")
-            )
-            save_count += 1
-        except StopIteration:
-            return
 
 
 def yield_pickled_files(

--- a/cyclops/utils/file.py
+++ b/cyclops/utils/file.py
@@ -8,7 +8,6 @@ from typing import Any, Generator, List, Optional, Union
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import dask.dataframe as dd
 
 from cyclops.utils.log import setup_logging
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -22,8 +22,8 @@ The implemented use cases include:
 🐣 Getting Started
 ==================
 
-Installing the cyclops package using pip
-----------------------------------------
+Installing cyclops using pip
+----------------------------
 
 .. code:: bash
 

--- a/tests/cyclops/query/test_interface.py
+++ b/tests/cyclops/query/test_interface.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-from typing import Generator
 from unittest.mock import patch
 
 import pandas as pd
@@ -40,11 +39,6 @@ def test_query_interface(
     query_interface.save(path, file_format="csv")
     with pytest.raises(ValueError):
         query_interface.save(path, file_format="donkey")
-
-    generator = query_interface.run_in_grouped_batches(id_col="donkey", batch_size=10)
-    assert isinstance(generator, Generator)
-
-    query_interface.save_in_grouped_batches("test_save", id_col="donkey", batch_size=10)
 
 
 @patch("cyclops.query.orm.Database")

--- a/tests/cyclops/query/test_interface.py
+++ b/tests/cyclops/query/test_interface.py
@@ -68,6 +68,12 @@ def test_query_interface_integration():
     # check that the partitions don't overlap
     assert len(set(vistit_ids_0).intersection(set(vistit_ids_1))) == 0
 
+    # test running a query using SQL string
+    synthea_db = visits.database
+    visits_df = synthea_db.run_query("SELECT * FROM cdm_synthea10.visit_occurrence")
+    assert isinstance(visits_df, pd.DataFrame)
+    assert visits_df.shape[0] > 0
+
 
 @patch("cyclops.query.orm.Database")
 @patch("sqlalchemy.sql.selectable.Subquery")

--- a/tests/cyclops/query/test_omop.py
+++ b/tests/cyclops/query/test_omop.py
@@ -6,8 +6,8 @@ from cyclops.query.omop import OMOPQuerier
 
 
 @pytest.mark.integration_test
-def test_omop_querier():
-    """Test OMOPQuerier."""
+def test_omop_querier_synthea():
+    """Test OMOPQuerier on synthea data."""
     synthea = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
     visits = synthea.visit_occurrence().run()
     persons = synthea.person().run()
@@ -19,3 +19,11 @@ def test_omop_querier():
     assert len(persons) == 109
     assert len(observations) == 16169
     assert len(measurements) == 19373
+
+
+@pytest.mark.integration_test
+def test_omop_querier_mimiciii():
+    """Test OMOPQuerier on MIMICIII data."""
+    mimic = OMOPQuerier("omop", database="mimiciii")
+    visits = mimic.visit_occurrence().run()
+    assert len(visits) == 58976

--- a/tests/cyclops/query/test_util.py
+++ b/tests/cyclops/query/test_util.py
@@ -59,7 +59,7 @@ def test_ends_with():
     )
 
 
-def test_startswith():
+def test_starts_with():
     """Test starts_with fn."""
     test_col = column("a")
     assert (

--- a/tests/cyclops/query/test_util.py
+++ b/tests/cyclops/query/test_util.py
@@ -12,6 +12,7 @@ from cyclops.query.util import (
     _to_subquery,
     ckwarg,
     drop_columns,
+    ends_with,
     equals,
     filter_columns,
     get_column,
@@ -25,6 +26,7 @@ from cyclops.query.util import (
     remove_kwargs,
     rename_columns,
     reorder_columns,
+    starts_with,
     table_params_to_type,
     trim_columns,
 )
@@ -47,6 +49,23 @@ def test_ckwarg():
     """Test ckwarg."""
     assert ckwarg({"arg1": 1}, "arg1") == 1
     assert ckwarg({"arg1": 1}, "arg2") is None
+
+
+def test_ends_with():
+    """Test ends_with."""
+    test_col = column("a")
+    assert (
+        str(ends_with(test_col, "a")) == "trim(lower(CAST(a AS VARCHAR))) LIKE :trim_1"
+    )
+
+
+def test_startswith():
+    """Test starts_with fn."""
+    test_col = column("a")
+    assert (
+        str(starts_with(test_col, "a"))
+        == "trim(lower(CAST(a AS VARCHAR))) LIKE :trim_1"
+    )
 
 
 def test_remove_kwargs():

--- a/tests/cyclops/utils/test_file.py
+++ b/tests/cyclops/utils/test_file.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 
 from cyclops.utils.file import (
-    concat_consequtive_dataframes,
     exchange_extension,
     join,
     listdir_nonhidden,
@@ -19,7 +18,6 @@ from cyclops.utils.file import (
     process_dir_save_path,
     process_file_save_path,
     save_array,
-    save_consequtive_dataframes,
     save_dataframe,
     save_pickle,
     yield_dataframes,
@@ -37,40 +35,6 @@ def test_yield_pickled_files():
     for pkl_file_content in yield_pickled_files("test_dir4", skip_n=1):
         TestCase().assertDictEqual(test_data, pkl_file_content)
     shutil.rmtree("./test_dir4")
-
-
-def test_concat_consequtive_save_dataframes():
-    """Test concat_consequtive_dataframes and save_consequtive_dataframes fn."""
-    test_df = pd.DataFrame([1, 2], columns=["a"])
-    os.makedirs("test_dir2", exist_ok=True)
-    save_dataframe(test_df, "test_dir2/df1")
-    save_dataframe(test_df, "test_dir2/df2")
-    save_dataframe(test_df, "test_dir2/df3")
-    save_dataframe(test_df, "test_dir2/df4")
-    for dataframe in concat_consequtive_dataframes("test_dir2", every_n=2):
-        assert dataframe.equals(
-            pd.DataFrame([1, 2, 1, 2], columns=["a"], index=[0, 1, 0, 1])
-        )
-
-    save_dataframe(test_df, "test_dir2/df5")
-    count = 0
-    for dataframe in concat_consequtive_dataframes("test_dir2", every_n=2):
-        if count == 2:
-            assert dataframe.equals(pd.DataFrame([1, 2], columns=["a"], index=[0, 1]))
-        else:
-            assert dataframe.equals(
-                pd.DataFrame([1, 2, 1, 2], columns=["a"], index=[0, 1, 0, 1])
-            )
-        count += 1
-
-    save_consequtive_dataframes("test_dir2", "test_dir3", every_n=2)
-    df1 = load_dataframe("test_dir3/batch_0000.parquet")
-    df2 = load_dataframe("test_dir3/batch_0001.parquet")
-    assert df1.equals(pd.DataFrame([1, 2, 1, 2], columns=["a"], index=[0, 1, 0, 1]))
-    assert df2.equals(pd.DataFrame([1, 2, 1, 2], columns=["a"], index=[0, 1, 0, 1]))
-
-    shutil.rmtree("test_dir2")
-    shutil.rmtree("test_dir3")
 
 
 def test_yield_dataframes():


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Feature/Fix

## Short Description
- Querying in batches was previously implemented using custom functions. This is however not extensible and prone to errors. Hence, using dask for querying in batches by having user specify backend seems like a better approach. Dask provides a DataFrame which can be used to apply methods supported by Pandas across partitions using lazy compute. Addresses #346.
- Add a couple of tests to query util funcs.
- Adds an integration test to make sure the queried batching works as expected.
- Add a simple integration test for querying mimic-iii database in OMOP format (just check number of visits).
- Cosmetic changes to README and intro.rst file for better readability.

## Tests Added/Modified
- tests/cyclops/utils/test_file.py
- tests/cyclops/query/test_interface.py
