### PR TITLE
Add test for load_dataframe supporting dask

### DIFF
--- a/cyclops/utils/file.py
+++ b/cyclops/utils/file.py
@@ -200,11 +200,17 @@ def load_dataframe(
         Loaded data.
 
     """
-    load_path = process_file_save_path(load_path, file_format)
+    is_dask = True
+    if not os.path.isdir(load_path):
+        load_path = process_file_save_path(load_path, file_format)
+        is_dask = False
     if log:
         LOGGER.info("Loading DataFrame from %s", load_path)
     if file_format == "parquet":
-        data = pd.read_parquet(load_path)
+        if is_dask:
+            data = dd.read_parquet(load_path)
+        else:
+            data = pd.read_parquet(load_path)
     elif file_format == "csv":
         data = pd.read_csv(load_path, index_col=[0])
     else:

--- a/cyclops/utils/file.py
+++ b/cyclops/utils/file.py
@@ -207,10 +207,8 @@ def load_dataframe(
     if log:
         LOGGER.info("Loading DataFrame from %s", load_path)
     if file_format == "parquet":
-        if is_dask:
-            data = dd.read_parquet(load_path)
-        else:
-            data = pd.read_parquet(load_path)
+        data_reader = dd.read_parquet if is_dask else pd.read_parquet
+        data = data_reader(load_path)
     elif file_format == "csv":
         data = pd.read_csv(load_path, index_col=[0])
     else:

--- a/tests/cyclops/utils/test_file.py
+++ b/tests/cyclops/utils/test_file.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from unittest import TestCase
 
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
@@ -142,6 +143,11 @@ def test_save_dataframe(
     loaded_data = pd.read_csv(path + ".csv", index_col=[0])
     assert loaded_data.equals(test_data_without_index)
 
+    dask_df = dd.from_pandas(test_data_with_index, npartitions=2)
+    save_dataframe(dask_df, path, file_format="parquet")
+    loaded_data = dd.read_parquet(path)
+    assert loaded_data.compute().equals(test_data_with_index)
+
     shutil.rmtree("test_save")
 
     with pytest.raises(ValueError):
@@ -179,6 +185,11 @@ def test_load_dataframe(
     save_dataframe(test_data_without_index, path, file_format="csv")
     loaded_data = load_dataframe(path, file_format="csv")
     assert loaded_data.equals(test_data_without_index)
+
+    dask_df = dd.from_pandas(test_data_with_index, npartitions=2)
+    save_dataframe(dask_df, path, file_format="parquet")
+    loaded_data = load_dataframe(path)
+    assert loaded_data.compute().equals(test_data_with_index)
 
     with pytest.raises(ValueError):
         load_dataframe(path, file_format="donkey")


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Fix

## Short Description
Add support to load dask dataframes using the load_dataframe function

## Tests Added
tests/cyclops/utils/test_file.py
