### PR TITLE
Refactor dataset query APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The python virtual environment can be set up using
 installed and then run:
 
 ```bash
-poetry install
+python3 -m poetry install
 source $(poetry env info --path)/bin/activate
 ```
 

--- a/apps/interface/app_query.py
+++ b/apps/interface/app_query.py
@@ -1,5 +1,7 @@
 """Querying functions used in the query page."""
 
+# pylint: disable=no-member
+
 from typing import Dict
 
 import pandas as pd
@@ -59,8 +61,9 @@ def query(  # pylint: disable=too-many-arguments
 
     if diagnosis_checked:
         if encounters is None:
-            diagnoses = db.diagnoses(**diagnosis_kwargs).run()
-            datas[APP_DIAG] = diagnoses
+            # diagnoses = db.diagnoses(**diagnosis_kwargs).run()
+            # datas[APP_DIAG] = diagnoses
+            datas[APP_DIAG] = None
         else:
             diagnoses = patient_diagnoses(diagnosis_kwargs).run()
             datas[APP_ENC] = pd.merge(

--- a/cyclops/query/base.py
+++ b/cyclops/query/base.py
@@ -65,6 +65,7 @@ class DatasetQuerier:
     def get_interface(
         self,
         table: TableTypes,
+        ops: Optional[qo.Sequential] = None,
         process_fn: Optional[Callable] = None,
     ) -> Union[QueryInterface, QueryInterfaceProcessed]:
         """Get a query interface for a GEMINI table.
@@ -73,6 +74,8 @@ class DatasetQuerier:
         ----------
         table
             Table to wrap in the interface.
+        ops: cyclops.query.ops.Sequential
+            Operations to perform on the query.
         process_fn
             Process function to apply on the Pandas DataFrame returned from the query.
 
@@ -84,9 +87,9 @@ class DatasetQuerier:
 
         """
         if process_fn is None:
-            return QueryInterface(self._db, table)
+            return QueryInterface(self._db, table, ops=ops)
 
-        return QueryInterfaceProcessed(self._db, table, process_fn)
+        return QueryInterfaceProcessed(self._db, table, ops=ops, process_fn=process_fn)
 
     def get_table(self, table_name: str, rename: bool = True) -> Subquery:
         """Get a table and possibly map columns to have standard names.

--- a/cyclops/query/base.py
+++ b/cyclops/query/base.py
@@ -2,7 +2,7 @@
 
 import logging
 from functools import partial
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, Generator, Mapping, Optional, Union
 
 from hydra import compose, initialize
 from omegaconf import OmegaConf
@@ -50,17 +50,17 @@ class DatasetQuerier:
     ----------
     _db: cyclops.query.orm.Database
         ORM Database used to run queries.
-    _table_map: Dict
+    _table_map: Mapping
         A dictionary mapping table names to table objects in the DB.
 
     """
 
-    def __init__(self, table_map: Dict, **config_overrides) -> None:
+    def __init__(self, table_map: Mapping, **config_overrides) -> None:
         """Initialize.
 
         Parameters
         ----------
-        table_map: Dict
+        table_map: Mapping
             A dictionary mapping table names to table objects in the DB.
         **config_overrides
              Override configuration parameters, specified as kwargs.
@@ -80,12 +80,12 @@ class DatasetQuerier:
         self._table_map = table_map
         self._setup_table_methods()
 
-    def list_tables(self) -> list:
+    def list_tables(self) -> Generator[str, None, None]:
         """List table methods that can be queried using the database.
 
         Returns
         -------
-        list
+        Generator[str, None, None]
             List of table names.
 
         """
@@ -122,7 +122,7 @@ class DatasetQuerier:
         return QueryInterfaceProcessed(self._db, table, ops=ops, process_fn=process_fn)
 
     def get_table(
-        self, table_name: str, cast_timestamp_cols: Optional[bool] = True
+        self, table_name: str, cast_timestamp_cols: bool = True
     ) -> Subquery:
         """Get a table and possibly map columns to have standard names.
 
@@ -133,7 +133,7 @@ class DatasetQuerier:
         ----------
         table_name: str
             Name of GEMINI table.
-        cast_timestamp_cols: bool, optional
+        cast_timestamp_cols: bool
             Whether to cast timestamp columns to datetime.
 
         Returns

--- a/cyclops/query/base.py
+++ b/cyclops/query/base.py
@@ -1,6 +1,7 @@
 """Base querier class."""
 
 import logging
+from functools import partial
 from typing import Callable, Dict, Optional, Union
 
 from hydra import compose, initialize
@@ -18,6 +19,30 @@ LOGGER = logging.getLogger(__name__)
 setup_logging(print_level="INFO", logger=LOGGER)
 
 
+def _cast_timestamp_cols(table: Subquery) -> Subquery:
+    """Cast timestamp columns to datetime.
+
+    Parameters
+    ----------
+    table: sqlalchemy.sql.selectable.Subquery
+        Table to cast.
+
+    Returns
+    -------
+    sqlalchemy.sql.selectable.Subquery
+        Table with cast columns.
+
+    """
+    cols_to_cast = []
+    for col in table.columns:
+        if str(col.type) == "TIMESTAMP":
+            cols_to_cast.append(col.name)
+    if cols_to_cast:
+        table = qo.Cast(cols_to_cast, "timestamp")(table)
+
+    return table
+
+
 class DatasetQuerier:
     """Base class to query EHR datasets.
 
@@ -27,22 +52,16 @@ class DatasetQuerier:
         ORM Database used to run queries.
     _table_map: Dict
         A dictionary mapping table names to table objects in the DB.
-    _column_map: Dict
-        A dictionary mapping column names from the database to map to output
-        in a consistent format.
 
     """
 
-    def __init__(self, table_map: Dict, column_map: Dict, **config_overrides) -> None:
+    def __init__(self, table_map: Dict, **config_overrides) -> None:
         """Initialize.
 
         Parameters
         ----------
-        table_map
+        table_map: Dict
             A dictionary mapping table names to table objects in the DB.
-        column_map
-            A dictionary mapping column names from the database to map to output
-            in a consistent format.
         **config_overrides
              Override configuration parameters, specified as kwargs.
 
@@ -59,7 +78,18 @@ class DatasetQuerier:
 
         self._db = Database(config)
         self._table_map = table_map
-        self._column_map = column_map
+        self._setup_table_methods()
+
+    def list_tables(self) -> list:
+        """List table methods that can be queried using the database.
+
+        Returns
+        -------
+        list
+            List of table names.
+
+        """
+        return list(self._table_map.keys())
 
     @table_params_to_type(Subquery)
     def get_interface(
@@ -72,7 +102,7 @@ class DatasetQuerier:
 
         Parameters
         ----------
-        table
+        table: cyclops.query.util.TableTypes
             Table to wrap in the interface.
         ops: cyclops.query.ops.Sequential
             Operations to perform on the query.
@@ -91,7 +121,9 @@ class DatasetQuerier:
 
         return QueryInterfaceProcessed(self._db, table, ops=ops, process_fn=process_fn)
 
-    def get_table(self, table_name: str, rename: bool = True) -> Subquery:
+    def get_table(
+        self, table_name: str, cast_timestamp_cols: Optional[bool] = True
+    ) -> Subquery:
         """Get a table and possibly map columns to have standard names.
 
         Standardizing column names allows for for columns to be
@@ -99,10 +131,10 @@ class DatasetQuerier:
 
         Parameters
         ----------
-        table_name
+        table_name: str
             Name of GEMINI table.
-        rename
-            Whether to map the column names
+        cast_timestamp_cols: bool, optional
+            Whether to cast timestamp columns to datetime.
 
         Returns
         -------
@@ -115,7 +147,48 @@ class DatasetQuerier:
 
         table = self._table_map[table_name](self._db).data
 
-        if rename:
-            table = qo.Rename(self._column_map, check_exists=False)(table)
+        if cast_timestamp_cols:
+            table = _cast_timestamp_cols(table)
 
         return _to_subquery(table)
+
+    def _template_table_method(
+        self,
+        table_name: str,
+        join: Optional[qo.JoinArgs] = None,
+        ops: Optional[qo.Sequential] = None,
+    ) -> QueryInterface:
+        """Template method for table methods.
+
+        Parameters
+        ----------
+        table_name: str
+            Name of table in the database.
+        join: cyclops.query.ops.JoinArgs
+            Join arguments.
+        ops: cyclops.query.ops.Sequential
+            Operations to perform on the query.
+
+        Returns
+        -------
+        cyclops.query.interface.QueryInterface
+            A query interface object.
+
+        """
+        table = self.get_table(table_name)
+
+        return QueryInterface(self._db, table, join=join, ops=ops)
+
+    def _setup_table_methods(self) -> None:
+        """Add table methods.
+
+        This method adds methods to the querier class that allow querying of tables in
+        the database. The methods are named after the table names.
+
+        """
+        for table_name in self._table_map:
+            setattr(
+                self,
+                table_name,
+                partial(self._template_table_method, table_name=table_name),
+            )

--- a/cyclops/query/gemini.py
+++ b/cyclops/query/gemini.py
@@ -437,7 +437,7 @@ class GEMINIQuerier(DatasetQuerier):
             Limit the number of rows returned.
 
         """
-        filter_care_unit_cols = qo.FilterColumns(
+        filter_care_unit_cols = qo.Keep(
             [
                 ENCOUNTER_ID,
                 "admit",
@@ -770,7 +770,7 @@ class GEMINIQuerier(DatasetQuerier):
 
         operations: List[tuple] = [
             (
-                qo.FilterColumns,
+                qo.Keep,
                 [
                     qo.QAP(
                         "variables",

--- a/cyclops/query/interface.py
+++ b/cyclops/query/interface.py
@@ -1,7 +1,7 @@
 """A query interface class to wrap database objects and queries."""
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Callable, Dict, Literal, Optional, Union
 
 import dask.dataframe as dd
@@ -54,7 +54,7 @@ class QueryInterface:
     def __post_init__(self) -> None:
         """Post init method to chain operations with original query."""
         if self.join:
-            self.query = qo.Join(**self.join._asdict())(self.query)
+            self.query = qo.Join(**asdict(self.join))(self.query)
         if self.ops:
             self.query = self.ops(self.query)
 
@@ -190,7 +190,7 @@ class QueryInterfaceProcessed:
     def __post_init__(self) -> None:
         """Post init method to chain operations with original query."""
         if self.join:
-            self._query = qo.Join(**self.join._asdict())(self._query)
+            self._query = qo.Join(**asdict(self.join))(self._query)
         if self.ops:
             self._query = self.ops(self._query)
 

--- a/cyclops/query/interface.py
+++ b/cyclops/query/interface.py
@@ -53,9 +53,9 @@ class QueryInterface:
 
     def __post_init__(self) -> None:
         """Post init method to chain operations with original query."""
-        if self.join:
+        if self.join is not None:
             self.query = qo.Join(**asdict(self.join))(self.query)
-        if self.ops:
+        if self.ops is not None:
             self.query = self.ops(self.query)
 
     @property
@@ -189,9 +189,9 @@ class QueryInterfaceProcessed:
 
     def __post_init__(self) -> None:
         """Post init method to chain operations with original query."""
-        if self.join:
+        if self.join is not None:
             self._query = qo.Join(**asdict(self.join))(self._query)
-        if self.ops:
+        if self.ops is not None:
             self._query = self.ops(self._query)
 
     def run(

--- a/cyclops/query/interface.py
+++ b/cyclops/query/interface.py
@@ -34,17 +34,13 @@ class QueryInterface:
         Operations to perform on the query.
     _data: pandas.DataFrame or dask.DataFrame
         Data returned from executing the query, as Pandas DataFrame.
-    _run_args: dict
-        Private dictionary attribute to keep track of arguments
+    _run_args: dict Private dictionary attribute to keep track of arguments
         passed to run() method.
 
     Notes
     -----
-    After initialization, the query is automatically chained with the operations, and
-    the query attribute is updated.
-
-    The data attribute is private, and should not be accessed directly. Use the run()
-    method to fetch data.
+    After initialization, the query, join operation and chaining of provided operations,
+    are automatically done and the query attribute is updated.
 
     """
 
@@ -175,6 +171,11 @@ class QueryInterfaceProcessed:
     _run_args: dict
         Private dictionary attribute to keep track of arguments
         passed to run() method.
+
+    Notes
+    -----
+    After initialization, the query, join operation and chaining of provided operations,
+    are automatically done and the query attribute is updated.
 
     """
 

--- a/cyclops/query/mimiciv.py
+++ b/cyclops/query/mimiciv.py
@@ -4,43 +4,16 @@ Supports querying of MIMICIV-2.0.
 
 """
 
-# pylint: disable=duplicate-code
-
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from sqlalchemy import Integer, func, select
-from sqlalchemy.sql.selectable import Subquery
 
 import cyclops.query.ops as qo
-from cyclops.process.column_names import (
-    ADMIT_TIMESTAMP,
-    AGE,
-    DATE_OF_DEATH,
-    DIAGNOSIS_CODE,
-    DIAGNOSIS_TITLE,
-    DIAGNOSIS_VERSION,
-    DISCHARGE_TIMESTAMP,
-    ENCOUNTER_ID,
-    EVENT_CATEGORY,
-    EVENT_NAME,
-    EVENT_TIMESTAMP,
-    EVENT_VALUE,
-    EVENT_VALUE_UNIT,
-    SEX,
-    SUBJECT_ID,
-)
 from cyclops.query.base import DatasetQuerier
 from cyclops.query.interface import QueryInterface, QueryInterfaceProcessed
 from cyclops.query.post_process.mimiciv import process_mimic_care_units
-from cyclops.query.util import (
-    TableTypes,
-    assert_table_has_columns,
-    ckwarg,
-    get_column,
-    remove_kwargs,
-    table_params_to_type,
-)
+from cyclops.query.util import get_column
 from cyclops.utils.log import setup_logging
 
 # Logging.
@@ -52,35 +25,27 @@ setup_logging(print_level="INFO", logger=LOGGER)
 PATIENTS = "patients"
 ADMISSIONS = "admissions"
 DIAGNOSES = "diagnoses"
-PATIENT_DIAGNOSES = "patient_diagnoses"
-EVENT_LABELS = "event_labels"
-EVENTS = "events"
+DIM_DIAGNOSES = "dim_diagnoses"
+DIM_ITEMS = "dim_items"
+DIM_LABITEMS = "dim_labitems"
+CHARTEVENTS = "chartevents"
 TRANSFERS = "transfers"
-ED_STAYS = "ed_stays"
+PHARMACY = "pharmacy"
+LABEVENTS = "labevents"
+EDSTAYS = "ed_stays"
+
 TABLE_MAP = {
     PATIENTS: lambda db: db.mimiciv_hosp.patients,
     ADMISSIONS: lambda db: db.mimiciv_hosp.admissions,
-    DIAGNOSES: lambda db: db.mimiciv_hosp.d_icd_diagnoses,
-    PATIENT_DIAGNOSES: lambda db: db.mimiciv_hosp.diagnoses_icd,
-    EVENT_LABELS: lambda db: db.mimiciv_icu.d_items,
-    EVENTS: lambda db: db.mimiciv_icu.chartevents,
+    DIAGNOSES: lambda db: db.mimiciv_hosp.diagnoses_icd,
+    DIM_DIAGNOSES: lambda db: db.mimiciv_hosp.d_icd_diagnoses,
+    DIM_LABITEMS: lambda db: db.mimiciv_hosp.d_labitems,
+    DIM_ITEMS: lambda db: db.mimiciv_icu.d_items,
+    CHARTEVENTS: lambda db: db.mimiciv_icu.chartevents,
+    LABEVENTS: lambda db: db.mimiciv_hosp.labevents,
+    PHARMACY: lambda db: db.mimiciv_hosp.pharmacy,
     TRANSFERS: lambda db: db.mimiciv_hosp.transfers,
-    ED_STAYS: lambda db: db.mimic_ed.edstays,
-}
-COLUMN_MAP = {
-    "hadm_id": ENCOUNTER_ID,
-    "subject_id": SUBJECT_ID,
-    "admittime": ADMIT_TIMESTAMP,
-    "dischtime": DISCHARGE_TIMESTAMP,
-    "gender": SEX,
-    "anchor_age": AGE,
-    "valueuom": EVENT_VALUE_UNIT,
-    "label": EVENT_NAME,
-    "valuenum": EVENT_VALUE,
-    "charttime": EVENT_TIMESTAMP,
-    "icd_code": DIAGNOSIS_CODE,
-    "icd_version": DIAGNOSIS_VERSION,
-    "dod": DATE_OF_DEATH,
+    EDSTAYS: lambda db: db.mimic_ed.edstays,
 }
 
 
@@ -99,7 +64,7 @@ class MIMICIVQuerier(DatasetQuerier):
         overrides = {}
         if config_overrides:
             overrides = config_overrides
-        super().__init__(TABLE_MAP, COLUMN_MAP, **overrides)
+        super().__init__(TABLE_MAP, **overrides)
 
     def patients(
         self,
@@ -122,7 +87,8 @@ class MIMICIVQuerier(DatasetQuerier):
         -----
         The function infers the approximate year a patient received care, using the
         `anchor_year` and `anchor_year_group` columns. The `join` and `ops` supplied
-        are applied after the approximate year is inferred.
+        are applied after the approximate year is inferred. `dod` is
+        adjusted based on the inferred approximate year of care.
 
         """
         table = self.get_table(PATIENTS)
@@ -160,380 +126,121 @@ class MIMICIVQuerier(DatasetQuerier):
         ).subquery()
 
         # Shift relevant columns by anchor year difference
-        # Calculate approximate year of birth
-        ops = qo.Sequential(
+        table = qo.AddDeltaColumn("dod", years="anchor_year_difference")(table)
+        table = qo.Drop(
             [
-                qo.AddColumn("anchor_year", "anchor_year_difference"),
-                qo.AddDeltaColumn([DATE_OF_DEATH], years="anchor_year_difference"),
-                qo.AddColumn(
-                    "anchor_year", "age", negative=True, new_col_labels="birth_year"
-                ),
-                qo.Drop(
-                    [
-                        "age",
-                        "anchor_year",
-                        "anchor_year_group",
-                        "anchor_year_group_start",
-                        "anchor_year_group_end",
-                        "anchor_year_group_middle",
-                    ]
-                ),
-                qo.Reorder(
-                    [
-                        SUBJECT_ID,
-                        SEX,
-                        "birth_year",
-                        DATE_OF_DEATH,
-                        "anchor_year_difference",
-                    ]
-                ),
-                ops,
+                "anchor_year_group_start",
+                "anchor_year_group_end",
+                "anchor_year_group_middle",
             ]
-        )
+        )(table)
 
         return QueryInterface(self._db, table, join=join, ops=ops)
 
-    def diagnoses(self, **process_kwargs) -> QueryInterface:
-        """Query MIMIC diagnoses.
+    def diagnoses(
+        self,
+        join: Optional[qo.JoinArgs] = None,
+        ops: Optional[qo.Sequential] = None,
+    ) -> QueryInterface:
+        """Query MIMIC diagnosis data.
+
+        Parameters
+        ----------
+        join: qo.JoinArgs, optional
+        ops: qo.Sequential, optional
 
         Returns
         -------
         cyclops.query.interface.QueryInterface
-            Constructed table, wrapped in an interface object.
-
-        Other Parameters
-        ----------------
-        diagnosis_versions: int or list of int, optional
-            Get codes having certain ICD versions.
-        diagnosis_substring : str, optional
-            Substring to match in the ICD code.
-        diagnosis_codes : str or list of str, optional
-            Get only the specified ICD codes.
-        limit: int, optional
-            Limit the number of rows returned.
+            Constructed query, wrapped in an interface object.
 
         """
         table = self.get_table(DIAGNOSES)
 
-        # Rename long_title
-        table = qo.Rename({"long_title": DIAGNOSIS_TITLE})(table)
-
-        # Trim whitespace from ICD codes.
-        table = qo.Trim(DIAGNOSIS_CODE)(table)
-
-        # Process optional operations
-        operations: List[tuple] = [
-            (
-                qo.ConditionIn,
-                [DIAGNOSIS_VERSION, qo.QAP("diagnosis_versions")],
-                {"to_int": True},
-            ),
-            (
-                qo.ConditionSubstring,
-                [DIAGNOSIS_TITLE, qo.QAP("diagnosis_substring")],
-                {},
-            ),
-            (
-                qo.ConditionIn,
-                [DIAGNOSIS_CODE, qo.QAP("diagnosis_codes")],
-                {"to_str": True},
-            ),
-            (qo.Limit, [qo.QAP("limit")], {}),
-        ]
-
-        table = qo.process_operations(table, operations, process_kwargs)
-
-        return QueryInterface(self._db, table)
-
-    @table_params_to_type(Subquery)
-    @assert_table_has_columns(patients_table=SUBJECT_ID)
-    def patient_diagnoses(
-        self, patients_table: Optional[TableTypes] = None, **process_kwargs
-    ) -> QueryInterface:
-        """Query MIMIC patient diagnoses.
-
-        Parameters
-        ----------
-        patients: cyclops.query.util.TableTypes, optional
-            Patient encounters query used to join.
-
-        Returns
-        -------
-        cyclops.query.interface.QueryInterface
-            Constructed table, wrapped in an interface object.
-
-        Other Parameters
-        ----------------
-        diagnosis_versions: int or list of int, optional
-            Get codes having certain ICD versions.
-        diagnosis_substring: str, optional
-            Substring to match in the ICD code.
-        diagnosis_codes: str or list of str, optional
-            Get only the specified ICD codes.
-
-        """
-        # Get patient diagnoses.
-        table = self.get_table(PATIENT_DIAGNOSES)
-
-        # Trim whitespace from ICD codes.
-        table = qo.Trim(DIAGNOSIS_CODE)(table)
-
-        # If provided, join with a patients table
-        if patients_table is not None:
-            table = qo.Join(patients_table, on=SUBJECT_ID)(table)
-
-        # Get diagnosis codes.
-        diagnoses_table = self.diagnoses(
-            diagnosis_versions=ckwarg(process_kwargs, "diagnosis_versions"),
-            diagnosis_substring=ckwarg(process_kwargs, "diagnosis_substring"),
-            diagnosis_codes=ckwarg(process_kwargs, "diagnosis_codes"),
-        ).query
-        process_kwargs = remove_kwargs(
-            process_kwargs,
-            ["diagnosis_versions", "diagnosis_substring", "diagnosis_codes"],
-        )
-
-        # Include DIAGNOSIS_TITLE in patient diagnoses.
+        # Join with diagnoses dimension table.
         table = qo.Join(
-            diagnoses_table,
-            on=[DIAGNOSIS_CODE, DIAGNOSIS_VERSION],
-            join_table_cols=DIAGNOSIS_TITLE,
+            join_table=self.get_table(DIM_DIAGNOSES),
+            on=["icd_code", "icd_version"],
+            on_to_type=["str", "int"],
         )(table)
 
-        return QueryInterface(self._db, table)
+        return QueryInterface(self._db, table, join=join, ops=ops)
 
-    @table_params_to_type(Subquery)
-    @assert_table_has_columns(patients_table=SUBJECT_ID)
-    def transfers(
-        self, patients_table: Optional[TableTypes] = None, **process_kwargs
-    ) -> QueryInterface:
-        """Get care unit table within a given set of encounters.
-
-        Parameters
-        ----------
-        patients_table: cyclops.query.util.TableTypes, optional
-            Patient encounters used to join.
-
-        Returns
-        -------
-        cyclops.query.interface.QueryInterface
-            Constructed table, wrapped in an interface object.
-
-        Other Parameters
-        ----------------
-        encounters : list, optional
-            The encounter IDs on which to filter. If None, consider all encounters.
-        limit: int, optional
-            Limit the number of rows returned.
-
-        """
-        table = self.get_table(TRANSFERS)
-
-        if patients_table is not None:
-            table = qo.Join(patients_table, on=SUBJECT_ID)(table)
-
-            table = qo.AddDeltaColumn(
-                ["intime", "outtime"], years="anchor_year_difference"
-            )(table)
-
-        # Process optional operations
-        operations: List[tuple] = [
-            (qo.ConditionIn, [ENCOUNTER_ID, qo.QAP("encounters")], {"to_int": True}),
-            (qo.Limit, [qo.QAP("limit")], {}),
-        ]
-
-        table = qo.process_operations(table, operations, process_kwargs)
-
-        return QueryInterface(self._db, table)
-
-    @table_params_to_type(Subquery)
-    @assert_table_has_columns(patients_table=SUBJECT_ID)
     def care_units(
-        self, patients_table: Optional[TableTypes] = None, **process_kwargs
+        self, join: Optional[qo.JoinArgs] = None, ops: Optional[qo.Sequential] = None
     ) -> QueryInterfaceProcessed:
         """Get care unit table within a given set of encounters.
 
         Parameters
         ----------
-        patients_table: cyclops.query.util.TableTypes, optional
-            Patient encounters to join with transfers.
+        join: qo.JoinArgs, optional
+        ops: qo.Sequential, optional
 
         Returns
         -------
         cyclops.query.interface.QueryInterfaceProcessed
             Constructed table, wrapped in an interface object.
 
-        Other Parameters
-        ----------------
-        encounters : int or list of int, optional
-            Get the specific encounter IDs.
-
         """
-        table = self.transfers(
-            patients_table=patients_table,
-            encounters=ckwarg(process_kwargs, "encounters"),
-        ).query
-
-        process_kwargs = remove_kwargs(process_kwargs, "encounters")
-
+        table = self.get_table(TRANSFERS)
         return QueryInterfaceProcessed(
             self._db,
             table,
             process_fn=lambda x: process_mimic_care_units(x, specific=False),
+            join=join,
+            ops=ops,
         )
 
-    @table_params_to_type(Subquery)
-    @assert_table_has_columns(patients_table=SUBJECT_ID)
-    def patient_encounters(
-        self, patients_table: Optional[TableTypes] = None, **process_kwargs
+    def labevents(
+        self, join: Optional[qo.JoinArgs] = None, ops: Optional[qo.Sequential] = None
     ) -> QueryInterface:
-        """Query MIMIC patient encounters.
+        """Query lab events from the hospital module.
 
         Parameters
         ----------
-        patients_table: cyclops.query.util.TableTypes, optional
-            Optionally provide a patient table when getting patient encounters.
+        join: qo.JoinArgs, optional
+        ops: qo.Sequential, optional
 
         Returns
         -------
         cyclops.query.interface.QueryInterface
-            Constructed table, wrapped in an interface object.
-
-        Other Parameters
-        ----------------
-        sex: str or list of string, optional
-            Specify patient sex (one or multiple).
-        died: bool, optional
-            Specify True to get patients who have died, and False for those who haven't.
-        died_binarize_col: str, optional
-            Binarize the died condition and save as a column with label
-            died_binarize_col.
-        before_date: datetime.datetime or str
-            Get patients encounters before some date.
-            If a string, provide in YYYY-MM-DD format.
-        after_date: datetime.datetime or str
-            Get patients encounters after some date.
-            If a string, provide in YYYY-MM-DD format.
-        years: int or list of int, optional
-            Get patient encounters by year.
-        months: int or list of int, optional
-            Get patient encounters by month.
-        limit: int, optional
-            Limit the number of rows returned.
+            Constructed query, wrapped in an interface object.
 
         """
-        table = self.get_table(ADMISSIONS)
+        table = self.get_table(LABEVENTS)
+        dim_items_table = self.get_table(DIM_LABITEMS)
 
-        if patients_table is None:
-            patients_table = self.patients().query
-
-        # Join admissions and patient table
-        table = qo.Join(patients_table, on="subject_id")(table)
-
-        # Update timestamps with anchor year difference
-        table = qo.AddDeltaColumn(
-            [
-                ADMIT_TIMESTAMP,
-                DISCHARGE_TIMESTAMP,
-                "deathtime",
-                "edregtime",
-                "edouttime",
-            ],
-            years="anchor_year_difference",
-        )(table)
-
-        # Extract approximate age at time of admission
-        table = qo.ExtractTimestampComponent(ADMIT_TIMESTAMP, "year", AGE)(table)
-        table = qo.AddColumn(AGE, "birth_year", negative=True)(table)
-        table = qo.ReorderAfter(AGE, SEX)(table)
-
-        # Process optional operations
-        if "died" not in process_kwargs and "died_binarize_col" in process_kwargs:
-            process_kwargs["died"] = True
-
-        operations: List[tuple] = [
-            (qo.ConditionBeforeDate, [ADMIT_TIMESTAMP, qo.QAP("before_date")], {}),
-            (qo.ConditionAfterDate, [ADMIT_TIMESTAMP, qo.QAP("after_date")], {}),
-            (qo.ConditionInYears, [ADMIT_TIMESTAMP, qo.QAP("years")], {}),
-            (qo.ConditionInMonths, [ADMIT_TIMESTAMP, qo.QAP("months")], {}),
-            (qo.ConditionIn, [SEX, qo.QAP("sex")], {"to_str": True}),
-            (
-                qo.ConditionEquals,
-                ["discharge_location", "DIED"],
-                {
-                    "not_": qo.QAP("died", transform_fn=lambda x: not x),
-                    "binarize_col": qo.QAP("died_binarize_col", required=False),
-                },
-            ),
-            (qo.Limit, [qo.QAP("limit")], {}),
-        ]
-
-        table = qo.process_operations(table, operations, process_kwargs)
-
-        return QueryInterface(self._db, table)
-
-    @table_params_to_type(Subquery)
-    @assert_table_has_columns(patient_encounters_table=[ENCOUNTER_ID, SUBJECT_ID])
-    def events(
-        self, patient_encounters_table: Optional[TableTypes] = None, **process_kwargs
-    ) -> QueryInterface:
-        """Query MIMIC events.
-
-        Parameters
-        ----------
-        patient_encounters_table: cyclops.query.util.TableTypes, optional
-            Optionally provide a patient encounter table to join with events.
-
-        Returns
-        -------
-        cyclops.query.interface.QueryInterface
-            Constructed table, wrapped in an interface object.
-
-        Other Parameters
-        ----------------
-        categories: str or list of str, optional
-            Restrict to certain categories.
-        event_names: str or list of str, optional
-            Restrict to certain event names.
-        event_name_substring: str, optional
-            Substring to search event names to filter.
-        limit: int, optional
-            Limit the number of rows returned.
-
-        """
-        table = self.get_table(EVENTS)
-        event_labels = self.get_table(EVENT_LABELS)
-
-        # Get category and event name
+        # Join with lab items dimension table.
         table = qo.Join(
-            event_labels, on="itemid", join_table_cols=["category", "event_name"]
+            join_table=dim_items_table,
+            on=["itemid"],
         )(table)
-        table = qo.Rename({"category": EVENT_CATEGORY})(table)
 
-        # Process optional operations
-        operations: List[tuple] = [
-            (qo.ConditionBeforeDate, [EVENT_TIMESTAMP, qo.QAP("before_date")], {}),
-            (qo.ConditionAfterDate, [EVENT_TIMESTAMP, qo.QAP("after_date")], {}),
-            (qo.ConditionInYears, [EVENT_TIMESTAMP, qo.QAP("years")], {}),
-            (qo.ConditionInMonths, [EVENT_TIMESTAMP, qo.QAP("months")], {}),
-            (qo.ConditionIn, [EVENT_CATEGORY, qo.QAP("categories")], {}),
-            (qo.ConditionIn, [EVENT_NAME, qo.QAP("event_names")], {}),
-            (qo.ConditionSubstring, [EVENT_NAME, qo.QAP("event_name_substring")], {}),
-            (qo.Limit, [qo.QAP("limit")], {}),
-        ]
+        return QueryInterface(self._db, table, join=join, ops=ops)
 
-        table = qo.process_operations(table, operations, process_kwargs)
+    def chartevents(
+        self, join: Optional[qo.JoinArgs] = None, ops: Optional[qo.Sequential] = None
+    ) -> QueryInterface:
+        """Query ICU chart events from the ICU module.
 
-        # Join on patient encounters
-        if patient_encounters_table is not None:
-            table = qo.Join(
-                patient_encounters_table,
-                on=ENCOUNTER_ID,
-            )(table)
+        Parameters
+        ----------
+        join: qo.JoinArgs, optional
+        ops: qo.Sequential, optional
 
-            # Add MIMIC patient-specific time difference to event/store timestamps
-            table = qo.AddDeltaColumn(
-                [EVENT_TIMESTAMP, "storetime"], years="anchor_year_difference"
-            )(table)
+        Returns
+        -------
+        cyclops.query.interface.QueryInterface
+            Constructed table, wrapped in an interface object.
 
-        return QueryInterface(self._db, table)
+        """
+        table = self.get_table(CHARTEVENTS)
+        dim_items_table = self.get_table(DIM_ITEMS)
+
+        # Join with items dimension table.
+        table = qo.Join(
+            dim_items_table,
+            on="itemid",
+        )(table)
+
+        return QueryInterface(self._db, table, join=join, ops=ops)

--- a/cyclops/query/mimiciv.py
+++ b/cyclops/query/mimiciv.py
@@ -150,7 +150,7 @@ class MIMICIVQuerier(DatasetQuerier):
 
         # Shift relevant columns by anchor year difference
         table = qo.AddColumn("anchor_year", "anchor_year_difference")(table)
-        table = qo.AddDeltaColumns([DATE_OF_DEATH], years="anchor_year_difference")(
+        table = qo.AddDeltaColumn([DATE_OF_DEATH], years="anchor_year_difference")(
             table
         )
 
@@ -336,7 +336,7 @@ class MIMICIVQuerier(DatasetQuerier):
         if patients_table is not None:
             table = qo.Join(patients_table, on=SUBJECT_ID)(table)
 
-            table = qo.AddDeltaColumns(
+            table = qo.AddDeltaColumn(
                 ["intime", "outtime"], years="anchor_year_difference"
             )(table)
 
@@ -435,7 +435,7 @@ class MIMICIVQuerier(DatasetQuerier):
         table = qo.Join(patients_table, on="subject_id")(table)
 
         # Update timestamps with anchor year difference
-        table = qo.AddDeltaColumns(
+        table = qo.AddDeltaColumn(
             [
                 ADMIT_TIMESTAMP,
                 DISCHARGE_TIMESTAMP,
@@ -536,7 +536,7 @@ class MIMICIVQuerier(DatasetQuerier):
             )(table)
 
             # Add MIMIC patient-specific time difference to event/store timestamps
-            table = qo.AddDeltaColumns(
+            table = qo.AddDeltaColumn(
                 [EVENT_TIMESTAMP, "storetime"], years="anchor_year_difference"
             )(table)
 

--- a/cyclops/query/orm.py
+++ b/cyclops/query/orm.py
@@ -4,7 +4,7 @@ import csv
 import logging
 import os
 import socket
-from typing import Literal, Optional, Union
+from typing import Generator, Literal, Optional, Union
 
 import dask.dataframe as dd
 import pandas as pd
@@ -116,6 +116,13 @@ class Database:
         session = sessionmaker(self.engine)
         session.configure(bind=self.engine)
         return session()
+
+    def tables(self, schema_name: str) -> Generator[str, None, None]:
+        """Get list of tables."""
+        metadata = MetaData(schema=schema_name)
+        metadata.reflect(bind=self.engine)
+
+        return (_get_attr_name(table_name) for table_name in metadata.tables.keys())
 
     def _setup(self):
         """Prepare ORM DB."""

--- a/cyclops/utils/plot.py
+++ b/cyclops/utils/plot.py
@@ -57,7 +57,7 @@ def plot_timeline(
         title="Timeline Visualization",
         autosize=True,
     )
-    if timesteps_ts:
+    if timesteps_ts is not None:
         for timestep_ts in timesteps_ts:
             fig.add_vline(timestep_ts)
 

--- a/cyclops/utils/plot.py
+++ b/cyclops/utils/plot.py
@@ -71,7 +71,7 @@ def plot_timeline(
     if return_fig:
         return fig
 
-    # fig = fig.update_layout(width=PLOT_HEIGHT * 2)
+    fig = fig.update_layout(width=PLOT_HEIGHT * 2)
     fig.show()
 
     return None

--- a/cyclops/utils/plot.py
+++ b/cyclops/utils/plot.py
@@ -10,12 +10,6 @@ from matplotlib.axes import SubplotBase
 from matplotlib.container import BarContainer
 from plotly.subplots import make_subplots
 
-from cyclops.process.column_names import (
-    EVENT_CATEGORY,
-    EVENT_NAME,
-    EVENT_TIMESTAMP,
-    EVENT_VALUE,
-)
 from cyclops.utils.common import to_list
 
 PLOT_HEIGHT = 520
@@ -23,7 +17,11 @@ PLOT_HEIGHT = 520
 
 def plot_timeline(
     events: pd.DataFrame,
-    timestep_timestamps: Optional[pd.Series] = None,
+    event_name: str,
+    event_ts: str,
+    event_value: str,
+    event_category: Optional[str] = None,
+    timesteps_ts: Optional[pd.Series] = None,
     return_fig: bool = False,
 ) -> Union[plotly.graph_objs.Figure, None]:
     """Plot timeline of patient events for an encounter.
@@ -32,7 +30,15 @@ def plot_timeline(
     ----------
     events: pandas.DataFrame
         Event data to plot.
-    timestep_timestamps: pandas.Series, optional
+    event_name: str
+        Name of column with event names.
+    event_ts: str
+        Name of column with event timestamps.
+    event_value: str
+        Name of column with event values.
+    event_category: str, optional
+        Name of column with category of events.
+    timesteps_ts: pandas.Series, optional
         Timestamps of timesteps to overlay as vertical lines.
         Useful to see aggregation buckets.
     return_fig: bool, optional
@@ -41,20 +47,19 @@ def plot_timeline(
     """
     fig = px.strip(
         events,
-        x=EVENT_TIMESTAMP,
-        y=EVENT_NAME,
-        color=EVENT_CATEGORY,
-        hover_data=[EVENT_VALUE],
+        x=event_ts,
+        y=event_name,
+        color=event_category,
+        hover_data=[event_value],
         stripmode="group",
     )
     fig.update_layout(
         title="Timeline Visualization",
-        autosize=False,
-        height=PLOT_HEIGHT,
+        autosize=True,
     )
-    if timestep_timestamps:
-        for timestep_timestamp in timestep_timestamps:
-            fig.add_vline(timestep_timestamp)
+    if timesteps_ts:
+        for timestep_ts in timesteps_ts:
+            fig.add_vline(timestep_ts)
 
     fig = fig.update_layout(
         {
@@ -66,7 +71,7 @@ def plot_timeline(
     if return_fig:
         return fig
 
-    fig = fig.update_layout(width=PLOT_HEIGHT * 2)
+    # fig = fig.update_layout(width=PLOT_HEIGHT * 2)
     fig.show()
 
     return None

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -40,7 +40,7 @@ sure it is installed and then run:
 
 .. code:: bash
 
-   poetry install
+   python3 -m poetry install
    source $(poetry env info --path)/bin/activate
 
 Contributing

--- a/docs/source/tutorials/mimiciv/query_api.ipynb
+++ b/docs/source/tutorials/mimiciv/query_api.ipynb
@@ -37,13 +37,33 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:34:11,469 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
+      "2023-01-30 15:16:11,459 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['patients',\n",
+       " 'admissions',\n",
+       " 'diagnoses',\n",
+       " 'dim_diagnoses',\n",
+       " 'dim_labitems',\n",
+       " 'dim_items',\n",
+       " 'chartevents',\n",
+       " 'labevents',\n",
+       " 'pharmacy',\n",
+       " 'transfers',\n",
+       " 'ed_stays']"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "import cyclops.query.ops as qo\n",
     "from cyclops.query import MIMICIVQuerier\n",
-    "from cyclops.query.ops import ConditionRegexMatch, ConditionStartsWith\n",
     "\n",
     "mimic = MIMICIVQuerier(\n",
     "    dbms=\"postgresql\",\n",
@@ -52,7 +72,9 @@
     "    database=\"mimiciv-2.0\",\n",
     "    user=\"postgres\",\n",
     "    password=\"pwd\",\n",
-    ")"
+    ")\n",
+    "# List all tables.\n",
+    "mimic.list_tables()"
    ]
   },
   {
@@ -62,7 +84,7 @@
     "tags": []
    },
    "source": [
-    "## Example 1. Get all patient encounters from 2015 (approximate year of care)."
+    "## Example 1. Get all patient admissions from 2021 or later (approx year of admission)"
    ]
   },
   {
@@ -75,22 +97,31 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:34:12,619 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:34:12,620 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.107362 s\n"
+      "2023-01-30 15:16:11,879 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 15:16:11,880 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.284805 s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "69460 rows extracted!\n"
+      "1575 rows extracted!\n"
      ]
     }
    ],
    "source": [
-    "encounters = mimic.patient_encounters(years=2015)\n",
-    "encounters.run()\n",
-    "print(f\"{len(encounters.data)} rows extracted!\")"
+    "patients = mimic.patients()\n",
+    "ops = qo.Sequential(\n",
+    "    [\n",
+    "        qo.AddDeltaColumn([\"admittime\", \"dischtime\"], years=\"anchor_year_difference\"),\n",
+    "        qo.ConditionAfterDate(\"admittime\", \"2021-01-01\"),\n",
+    "    ]\n",
+    ")\n",
+    "admissions = mimic.admissions(\n",
+    "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
+    "    ops=ops,\n",
+    ").run()\n",
+    "print(f\"{len(admissions)} rows extracted!\")"
    ]
   },
   {
@@ -98,7 +129,7 @@
    "id": "80d9f06e",
    "metadata": {},
    "source": [
-    "## Example 2. Get all patient encounters with diagnoses (`schizophrenia` in ICD long title), in the year 2015."
+    "## Example 2. Get all patient encounters with diagnoses (`schizophrenia` in ICD-10 long title), in the year 2015."
    ]
   },
   {
@@ -111,67 +142,44 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:34:13,405 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:34:13,406 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.756868 s\n"
+      "2023-01-30 15:16:12,872 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 15:16:12,873 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.874558 s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4731 rows extracted!\n"
+      "263 rows extracted!\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Unspecified schizophrenia, unspecified                                     1511\n",
-       "Schizophrenia, unspecified                                                 1431\n",
-       "Paranoid type schizophrenia, unspecified                                    527\n",
-       "Paranoid schizophrenia                                                      381\n",
-       "Paranoid type schizophrenia, chronic                                        279\n",
-       "Paranoid type schizophrenia, chronic with acute exacerbation                174\n",
-       "Unspecified schizophrenia, chronic                                           77\n",
-       "Catatonic schizophrenia                                                      68\n",
-       "Other specified types of schizophrenia, unspecified                          43\n",
-       "Catatonic type schizophrenia, unspecified                                    37\n",
-       "Other schizophrenia                                                          33\n",
-       "Disorganized type schizophrenia, chronic with acute exacerbation             20\n",
-       "Catatonic type schizophrenia, chronic with acute exacerbation                19\n",
-       "Disorganized type schizophrenia, unspecified                                 19\n",
-       "Unspecified schizophrenia, chronic with acute exacerbation                   18\n",
-       "Other specified types of schizophrenia, chronic with acute exacerbation      15\n",
-       "Personal history of schizophrenia                                            13\n",
-       "Paranoid type schizophrenia, subchronic with acute exacerbation              12\n",
-       "Disorganized schizophrenia                                                   11\n",
-       "Disorganized type schizophrenia, chronic                                      9\n",
-       "Catatonic type schizophrenia, chronic                                         7\n",
-       "Residual schizophrenia                                                        6\n",
-       "Catatonic type schizophrenia, subchronic with acute exacerbation              4\n",
-       "Other specified types of schizophrenia, chronic                               3\n",
-       "Paranoid type schizophrenia, subchronic                                       3\n",
-       "Simple type schizophrenia, unspecified                                        2\n",
-       "Disorganized type schizophrenia, subchronic with acute exacerbation           2\n",
-       "Simple type schizophrenia, chronic                                            2\n",
-       "Unspecified schizophrenia, in remission                                       2\n",
-       "Latent schizophrenia, unspecified                                             2\n",
-       "Undifferentiated schizophrenia                                                1\n",
-       "Name: diagnosis_title, dtype: int64"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "encounters = mimic.patient_encounters(years=[2015])\n",
-    "encounters_schizophrenia = mimic.patient_diagnoses(\n",
-    "    diagnosis_substring=\"schizophrenia\", patients=encounters\n",
+    "diagnoses_ops = qo.Sequential(\n",
+    "    [\n",
+    "        qo.ConditionEquals(\"icd_version\", 10),\n",
+    "        qo.ConditionSubstring(\"long_title\", \"schizophrenia\"),\n",
+    "    ]\n",
     ")\n",
-    "encounters_schizophrenia.run()\n",
-    "print(f\"{len(encounters_schizophrenia.data)} rows extracted!\")\n",
-    "encounters_schizophrenia.data[\"diagnosis_title\"].value_counts()"
+    "admissions_ops = qo.Sequential(\n",
+    "    [\n",
+    "        qo.AddDeltaColumn([\"admittime\", \"dischtime\"], years=\"anchor_year_difference\"),\n",
+    "        qo.ConditionInYears(\"admittime\", \"2015\"),\n",
+    "    ]\n",
+    ")\n",
+    "patients = mimic.patients()\n",
+    "admissions = mimic.admissions(\n",
+    "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
+    "    ops=admissions_ops,\n",
+    ")\n",
+    "diagnoses = mimic.diagnoses(\n",
+    "    join=qo.JoinArgs(\n",
+    "        join_table=admissions.query,\n",
+    "        on=[\"subject_id\", \"hadm_id\"],\n",
+    "    ),\n",
+    "    ops=diagnoses_ops,\n",
+    ").run()\n",
+    "print(f\"{len(diagnoses)} rows extracted!\")"
    ]
   },
   {
@@ -179,7 +187,7 @@
    "id": "e2baea54",
    "metadata": {},
    "source": [
-    "## Example 3. Advanced - uses `ConditionRegexMatch` from `cyclops.query.ops`. Get all patient encounters with diagnoses (ICD long title contains `schizophrenia` and `chronic` ), in the year 2015."
+    "## Example 3. Advanced - uses `ConditionRegexMatch` from `cyclops.query.ops`. Get all patient encounters with diagnoses (ICD-9 long title contains `schizophrenia` and `chronic` ), in the year 2015."
    ]
   },
   {
@@ -192,194 +200,44 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:34:14,681 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:34:14,682 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.248306 s\n"
+      "2023-01-30 15:16:14,524 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 15:16:14,525 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.533797 s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "644 rows extracted!\n"
+      "82 rows extracted!\n"
      ]
     }
    ],
    "source": [
-    "encounters = mimic.patient_encounters(years=[2015])\n",
-    "diagnoses = mimic.patient_diagnoses(patients=encounters)\n",
-    "patients_schizophrenia_chronic = ConditionRegexMatch(\n",
-    "    \"diagnosis_title\", r\"(?=.*schizophrenia)(?=.*chronic)\"\n",
-    ")(diagnoses.query)\n",
-    "data = mimic.get_interface(patients_schizophrenia_chronic).run()\n",
-    "print(f\"{len(data)} rows extracted!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "88e7bf6d",
-   "metadata": {},
-   "source": [
-    "## Example 4. Advanced - uses `ConditionStartsWith` from cyclops.query.ops. Get all patient encounters with diagnoses (starts with `Paranoid` in ICD long title), in the year 2015."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "f3f05615",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-16 12:34:24,056 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:34:24,057 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 9.342424 s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1429 rows extracted!\n"
-     ]
-    }
-   ],
-   "source": [
-    "encounters = mimic.patient_encounters(years=[2015])\n",
-    "diagnoses = mimic.patient_diagnoses(patients=encounters)\n",
-    "patients_paranoia = ConditionStartsWith(\"diagnosis_title\", \"Paranoid\")(diagnoses.query)\n",
-    "data = mimic.get_interface(patients_paranoia).run()\n",
-    "print(f\"{len(data)} rows extracted!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d093543f",
-   "metadata": {},
-   "source": [
-    "## Example 5. Get all patient encounters with diagnoses (ICD code is F209)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "105be34a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-16 12:34:32,477 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:34:32,478 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 8.393982 s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1431 rows extracted!\n"
-     ]
-    }
-   ],
-   "source": [
-    "patients = mimic.patients()\n",
-    "patients_f209 = mimic.patient_diagnoses(diagnosis_codes=[\"F209\"], patients=patients)\n",
-    "patients_f209.run()\n",
-    "print(f\"{len(patients_f209.data)} rows extracted!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "569ac1b0",
-   "metadata": {},
-   "source": [
-    "## Example 6. Get all patient encounters with diagnoses (`delirium` in ICD long title)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "73a46650",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-16 12:34:33,139 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:34:33,140 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.645764 s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9000 rows extracted!\n"
-     ]
-    }
-   ],
-   "source": [
-    "patients = mimic.patients()\n",
-    "patients_delirium = mimic.patient_diagnoses(\n",
-    "    diagnosis_substring=\"delirium\", patients=patients\n",
+    "admissions_ops = qo.Sequential(\n",
+    "    [\n",
+    "        qo.AddDeltaColumn([\"admittime\", \"dischtime\"], years=\"anchor_year_difference\"),\n",
+    "        qo.ConditionInYears(\"admittime\", \"2015\"),\n",
+    "    ]\n",
     ")\n",
-    "patients_delirium.run()\n",
-    "print(f\"{len(patients_delirium.data)} rows extracted!\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "cec91296-bc8f-4973-b544-9ce8ce4119e2",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Delirium due to conditions classified elsewhere                                  3938\n",
-       "Delirium due to known physiological condition                                    3075\n",
-       "Drug-induced delirium                                                             963\n",
-       "Alcohol withdrawal delirium                                                       373\n",
-       "Alcohol dependence with withdrawal delirium                                       210\n",
-       "Vascular dementia, with delirium                                                  169\n",
-       "Senile dementia with delirium                                                      88\n",
-       "Subacute delirium                                                                  35\n",
-       "Alcohol dependence with intoxication delirium                                      28\n",
-       "Alcohol abuse with intoxication delirium                                           20\n",
-       "Other psychoactive substance use, unspecified with intoxication with delirium      15\n",
-       "Sedative, hypnotic or anxiolytic dependence with withdrawal delirium               14\n",
-       "Opioid use, unspecified with intoxication delirium                                 10\n",
-       "Presenile dementia with delirium                                                    8\n",
-       "Other stimulant abuse with intoxication delirium                                    7\n",
-       "Other psychoactive substance abuse with intoxication delirium                       6\n",
-       "Cocaine abuse with intoxication with delirium                                       5\n",
-       "Opioid abuse with intoxication delirium                                             5\n",
-       "Other psychoactive substance use, unspecified with withdrawal delirium              4\n",
-       "Hallucinogen abuse with intoxication with delirium                                  3\n",
-       "Other stimulant dependence with intoxication delirium                               3\n",
-       "Cocaine dependence with intoxication delirium                                       3\n",
-       "Hallucinogen use, unspecified with intoxication with delirium                       2\n",
-       "Sedative, hypnotic or anxiolytic abuse with intoxication delirium                   2\n",
-       "Sedative, hypnotic or anxiolytic dependence with intoxication delirium              2\n",
-       "Other psychoactive substance dependence with intoxication delirium                  2\n",
-       "Opioid dependence with intoxication delirium                                        2\n",
-       "Sedative, hypnotic or anxiolytic use, unspecified with intoxication delirium        2\n",
-       "Cannabis abuse with intoxication delirium                                           2\n",
-       "Other stimulant use, unspecified with intoxication delirium                         1\n",
-       "Cannabis use, unspecified with intoxication delirium                                1\n",
-       "Other psychoactive substance dependence with withdrawal delirium                    1\n",
-       "Cocaine use, unspecified with intoxication delirium                                 1\n",
-       "Name: diagnosis_title, dtype: int64"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "patients_delirium.data[\"diagnosis_title\"].value_counts()"
+    "diagnoses_ops = qo.Sequential(\n",
+    "    [\n",
+    "        qo.ConditionEquals(\"icd_version\", 9),\n",
+    "        qo.ConditionRegexMatch(\"long_title\", r\"(?=.*schizophrenia)(?=.*chronic)\"),\n",
+    "    ]\n",
+    ")\n",
+    "patients = mimic.patients()\n",
+    "admissions = mimic.admissions(\n",
+    "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
+    "    ops=admissions_ops,\n",
+    ")\n",
+    "diagnoses = mimic.diagnoses(\n",
+    "    join=qo.JoinArgs(\n",
+    "        join_table=admissions.query,\n",
+    "        on=[\"subject_id\", \"hadm_id\"],\n",
+    "    ),\n",
+    "    ops=diagnoses_ops,\n",
+    ").run()\n",
+    "print(f\"{len(diagnoses)} rows extracted!\")"
    ]
   },
   {
@@ -387,12 +245,12 @@
    "id": "30b0d604",
    "metadata": {},
    "source": [
-    "## Example 7. Get routine vital signs for patients from year 2015, limit to 100 rows."
+    "## Example 4. Get routine vital signs for patients from year 2015, limit to 100 rows."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "id": "56a72377",
    "metadata": {},
    "outputs": [
@@ -400,8 +258,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:36:09,988 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:36:09,990 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 96.810362 s\n"
+      "2023-01-30 15:17:49,765 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 15:17:49,765 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 95.007937 s\n"
      ]
     },
     {
@@ -413,12 +271,26 @@
     }
    ],
    "source": [
-    "encounters = mimic.patient_encounters(years=[2018])\n",
-    "patients_vitals = mimic.events(\n",
-    "    patient_encounters_table=encounters.query, categories=\"Routine Vital Signs\"\n",
+    "admissions_ops = qo.Sequential(\n",
+    "    [\n",
+    "        qo.AddDeltaColumn([\"admittime\", \"dischtime\"], years=\"anchor_year_difference\"),\n",
+    "        qo.ConditionInYears(\"admittime\", \"2015\"),\n",
+    "    ]\n",
     ")\n",
-    "patients_vitals.run(limit=100)\n",
-    "print(f\"{len(patients_vitals.data)} rows extracted!\")"
+    "chartevents_ops = qo.Sequential([qo.ConditionEquals(\"category\", \"Routine Vital Signs\")])\n",
+    "patients = mimic.patients()\n",
+    "admissions = mimic.admissions(\n",
+    "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
+    "    ops=admissions_ops,\n",
+    ")\n",
+    "vitals = mimic.chartevents(\n",
+    "    join=qo.JoinArgs(\n",
+    "        join_table=admissions.query,\n",
+    "        on=[\"subject_id\", \"hadm_id\"],\n",
+    "    ),\n",
+    "    ops=chartevents_ops,\n",
+    ").run(limit=100)\n",
+    "print(f\"{len(vitals)} rows extracted!\")"
    ]
   },
   {
@@ -426,12 +298,12 @@
    "id": "621479f0",
    "metadata": {},
    "source": [
-    "## Example 8. Get hemoglobin lab tests for patients from year 2009, limit to 100 rows."
+    "## Example 5. Get hemoglobin lab tests for patients from year 2009, limit to 100 rows."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "id": "bce11f81",
    "metadata": {},
    "outputs": [
@@ -439,8 +311,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:36:11,696 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:36:11,698 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.677006 s\n"
+      "2023-01-30 15:19:03,562 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 15:19:03,563 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 73.678148 s\n"
      ]
     },
     {
@@ -452,173 +324,26 @@
     }
    ],
    "source": [
-    "encounters = mimic.patient_encounters(years=[2009])\n",
-    "patients_hemo_labs = mimic.events(\n",
-    "    categories=\"labs\",\n",
-    "    patient_encounters_table=encounters.query,\n",
-    "    event_names=\"hemoglobin\",\n",
+    "admissions_ops = qo.Sequential(\n",
+    "    [\n",
+    "        qo.AddDeltaColumn([\"admittime\", \"dischtime\"], years=\"anchor_year_difference\"),\n",
+    "        qo.ConditionInYears(\"admittime\", \"2009\"),\n",
+    "    ]\n",
     ")\n",
-    "patients_hemo_labs.run(limit=100)\n",
-    "print(f\"{len(patients_hemo_labs.data)} rows extracted!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "93e28422",
-   "metadata": {},
-   "source": [
-    "## Example 9. Get all lab events for patients from year 2010, that match substring \"sodium\", limit to 100 rows."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "9a6aeef6",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-16 12:36:14,289 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:36:14,290 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 2.549300 s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 rows extracted!\n"
-     ]
-    }
-   ],
-   "source": [
-    "encounters = mimic.patient_encounters(years=[2009])\n",
-    "patients_sodium_labs = mimic.events(\n",
-    "    categories=\"labs\",\n",
-    "    patient_encounters_table=encounters.query,\n",
-    "    event_name_substring=\"sodium\",\n",
-    ")\n",
-    "patients_sodium_labs.run(limit=100)\n",
-    "print(f\"{len(patients_sodium_labs.data)} rows extracted!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7d5d0e20",
-   "metadata": {},
-   "source": [
-    "## Example 10. Get respiratory events for patients from year 2009, limit to 100 rows."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "e9fc83e3",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-16 12:37:35,834 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:37:35,836 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 81.502515 s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 rows extracted!\n"
-     ]
-    }
-   ],
-   "source": [
-    "encounters = mimic.patient_encounters(years=[2009])\n",
-    "patients_respiratory = mimic.events(\n",
-    "    categories=\"Respiratory\", patient_encounters_table=encounters.query\n",
-    ")\n",
-    "patients_respiratory.run(limit=100)\n",
-    "print(f\"{len(patients_respiratory.data)} rows extracted!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "af3c3e3b",
-   "metadata": {},
-   "source": [
-    "## Example 11. Get heart rate measurements of patients with delirium diagnoses, limit to 100 rows."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "77453d72",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-16 12:38:50,455 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:38:50,457 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 74.580848 s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 rows extracted!\n"
-     ]
-    }
-   ],
-   "source": [
+    "labevents_ops = qo.Sequential([qo.ConditionEquals(\"label\", \"hemoglobin\")])\n",
     "patients = mimic.patients()\n",
-    "encounters = mimic.patient_encounters(patients_table=patients.query)\n",
-    "delirium_encounters = mimic.patient_diagnoses(\n",
-    "    diagnosis_substring=\"delirium\", patients_table=encounters.query\n",
+    "admissions = mimic.admissions(\n",
+    "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
+    "    ops=admissions_ops,\n",
     ")\n",
-    "patients_delirium_heart_rate = mimic.events(\n",
-    "    event_names=\"Heart Rate\", patient_encounters_table=delirium_encounters.query\n",
-    ")\n",
-    "patients_delirium_heart_rate.run(limit=100)\n",
-    "print(f\"{len(patients_delirium_heart_rate.data)} rows extracted!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f5efc21c",
-   "metadata": {},
-   "source": [
-    "## Example 12. Get d_items dimension table, for quick reference."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "9feecc43",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-16 12:38:50,497 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:38:50,498 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.030484 s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4014 rows extracted!\n"
-     ]
-    }
-   ],
-   "source": [
-    "event_lookup_table = mimic.get_interface(mimic.get_table(\"event_labels\"))\n",
-    "lookup_data = event_lookup_table.run()\n",
-    "print(f\"{len(lookup_data)} rows extracted!\")"
+    "labs = mimic.chartevents(\n",
+    "    join=qo.JoinArgs(\n",
+    "        join_table=admissions.query,\n",
+    "        on=[\"subject_id\", \"hadm_id\"],\n",
+    "    ),\n",
+    "    ops=labevents_ops,\n",
+    ").run(limit=100)\n",
+    "print(f\"{len(labs)} rows extracted!\")"
    ]
   },
   {
@@ -626,12 +351,12 @@
    "id": "801c5ec5-6c7e-44af-8fb7-275d66ca82b0",
    "metadata": {},
    "source": [
-    "## Example 13. Get all female patient encounters from year 2015, and return as dask dataframe (lazy evaluation) with 4 partitions (batches)."
+    "## Example 6. Get all female patient encounters from year 2015, and return as dask dataframe (lazy evaluation) with 4 partitions (batches) aggregated based on `subject_id`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "id": "28683d70-376e-4d9b-883d-1a7de634e455",
    "metadata": {},
    "outputs": [
@@ -639,8 +364,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:38:51,143 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:38:51,143 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.618330 s\n"
+      "2023-01-30 15:19:04,056 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 15:19:04,057 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.442855 s\n"
      ]
     },
     {
@@ -654,11 +379,22 @@
     }
    ],
    "source": [
-    "encounters = mimic.patient_encounters(years=2015, sex=\"F\")\n",
-    "encounters.run(backend=\"dask\", index_col=\"encounter_id\", n_partitions=4)\n",
-    "print(f\"{len(encounters.data)} rows extracted!\")\n",
-    "print(f\"Return type: {type(encounters.data)}\")\n",
-    "print(f\"Number of partitions: {encounters.data.npartitions}\")"
+    "admissions_ops = qo.Sequential(\n",
+    "    [\n",
+    "        qo.AddDeltaColumn([\"admittime\", \"dischtime\"], years=\"anchor_year_difference\"),\n",
+    "        qo.ConditionInYears(\"admittime\", \"2015\"),\n",
+    "        qo.Cast(\"gender\", \"str\"),\n",
+    "        qo.ConditionEquals(\"gender\", \"F\"),\n",
+    "    ]\n",
+    ")\n",
+    "patients = mimic.patients()\n",
+    "admissions = mimic.admissions(\n",
+    "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
+    "    ops=admissions_ops,\n",
+    ").run(backend=\"dask\", index_col=\"subject_id\", n_partitions=4)\n",
+    "print(f\"{len(admissions)} rows extracted!\")\n",
+    "print(f\"Return type: {type(admissions)}\")\n",
+    "print(f\"Number of partitions: {admissions.npartitions}\")"
    ]
   },
   {
@@ -666,12 +402,12 @@
    "id": "e1ed2708",
    "metadata": {},
    "source": [
-    "## Example 14. Running a raw SQL string."
+    "## Example 7. Running a raw SQL string."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "id": "a853deec",
    "metadata": {},
    "outputs": [
@@ -679,8 +415,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:38:52,854 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:38:52,854 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.008507 s\n"
+      "2023-01-30 15:19:05,133 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 15:19:05,134 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.006734 s\n"
      ]
     },
     {

--- a/docs/source/tutorials/synthea/query_api.ipynb
+++ b/docs/source/tutorials/synthea/query_api.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "id": "53009e6b",
    "metadata": {},
    "outputs": [
@@ -37,15 +37,32 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:41:50,331 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
+      "2023-01-30 14:47:55,129 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['visit_occurrence',\n",
+       " 'visit_detail',\n",
+       " 'person',\n",
+       " 'measurement',\n",
+       " 'observation',\n",
+       " 'concept',\n",
+       " 'care_site',\n",
+       " 'provider']"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "import pandas as pd\n",
     "\n",
+    "import cyclops.query.ops as qo\n",
     "from cyclops.query import OMOPQuerier\n",
-    "from cyclops.query.ops import ConditionAfterDate\n",
     "\n",
     "synthea = OMOPQuerier(\n",
     "    dbms=\"postgresql\",\n",
@@ -55,7 +72,9 @@
     "    user=\"postgres\",\n",
     "    password=\"pwd\",\n",
     "    schema_name=\"cdm_synthea10\",\n",
-    ")"
+    ")\n",
+    "# List all tables.\n",
+    "synthea.list_tables()"
    ]
   },
   {
@@ -70,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 2,
    "id": "3a3d9cb9-fe40-45b8-ba2f-8de52a3b7f4f",
    "metadata": {},
    "outputs": [
@@ -78,8 +97,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 12:43:15,959 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 12:43:15,960 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 5.230168 s\n"
+      "2023-01-30 14:48:00,694 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 14:48:00,695 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 5.527511 s\n"
      ]
     },
     {
@@ -92,34 +111,33 @@
     {
      "data": {
       "text/plain": [
-       "2014    44476\n",
-       "2020    39073\n",
-       "2019    32257\n",
-       "2018    31251\n",
-       "2017    30804\n",
-       "2015    30647\n",
-       "2022    30542\n",
-       "2016    30158\n",
-       "2021    29654\n",
-       "2013    29625\n",
-       "2012    10250\n",
-       "2011     8380\n",
        "2010     7968\n",
+       "2011     8380\n",
+       "2012    10250\n",
+       "2013    29625\n",
+       "2014    44476\n",
+       "2015    30647\n",
+       "2016    30158\n",
+       "2017    30804\n",
+       "2018    31251\n",
+       "2019    32257\n",
+       "2020    39073\n",
+       "2021    29654\n",
+       "2022    30542\n",
        "2023      209\n",
        "Name: visit_start_date, dtype: int64"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "visits = synthea.visit_occurrence().query\n",
-    "visits = ConditionAfterDate(\"visit_start_date\", \"2010-01-01\")(visits)\n",
-    "visits = synthea.get_interface(visits).run()\n",
+    "ops = qo.Sequential([qo.ConditionAfterDate(\"visit_start_date\", \"2010-01-01\")])\n",
+    "visits = synthea.visit_occurrence(ops=ops).run()\n",
     "print(f\"{len(visits)} rows extracted!\")\n",
-    "pd.to_datetime(visits[\"visit_start_date\"]).dt.year.value_counts()"
+    "pd.to_datetime(visits[\"visit_start_date\"]).dt.year.value_counts().sort_index()"
    ]
   },
   {
@@ -127,12 +145,12 @@
    "id": "fcaea674-b967-4fbc-a7be-4d8b4492ef56",
    "metadata": {},
    "source": [
-    "## Example 2. Get measurements for all visits in or after 2020."
+    "## Example 2. Get measurements for all visits in or after 2020, limit to first 100 rows."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 3,
    "id": "030e2491-a7cc-42f3-a1ca-618212b3524c",
    "metadata": {},
    "outputs": [
@@ -140,23 +158,24 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-16 13:48:57,161 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-16 13:48:57,163 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 47.342620 s\n"
+      "2023-01-30 14:48:00,923 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-01-30 14:48:00,924 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.073149 s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1781444 rows extracted!\n"
+      "100 rows extracted!\n"
      ]
     }
    ],
    "source": [
-    "visits = synthea.visit_occurrence().query\n",
-    "visits = ConditionAfterDate(\"visit_start_date\", \"2020-01-01\")(visits)\n",
-    "measurements = synthea.measurement(visit_occurrence_table=visits).query\n",
-    "measurements = synthea.get_interface(measurements).run()\n",
+    "ops = qo.Sequential([qo.ConditionAfterDate(\"visit_start_date\", \"2020-01-01\")])\n",
+    "visits = synthea.visit_occurrence(ops=ops)\n",
+    "measurements = synthea.measurement(\n",
+    "    join=qo.JoinArgs(join_table=visits.query, on=\"visit_occurrence_id\")\n",
+    ").run(limit=100)\n",
     "print(f\"{len(measurements)} rows extracted!\")"
    ]
   }

--- a/tests/cyclops/query/test_base.py
+++ b/tests/cyclops/query/test_base.py
@@ -5,4 +5,4 @@ from cyclops.query.base import DatasetQuerier
 
 def test_dataset_querier():
     """Test dataset querier instantiation."""
-    _ = DatasetQuerier({}, {})
+    _ = DatasetQuerier({})

--- a/tests/cyclops/query/test_interface.py
+++ b/tests/cyclops/query/test_interface.py
@@ -27,7 +27,7 @@ def test_query_interface(
     query_interface = QueryInterface(database, query)
     query_interface.run()
 
-    query_interface.data = test_data
+    query_interface._data = test_data  # pylint: disable=protected-access
     path = os.path.join("test_save", "test_features.parquet")
     query_interface.save(path)
     loaded_data = pd.read_parquet(path)
@@ -36,9 +36,6 @@ def test_query_interface(
     query_interface.clear_data()
     assert not query_interface.data
 
-    query_interface.data = None
-    query_interface.save(path)
-    query_interface.save(path, file_format="csv")
     with pytest.raises(ValueError):
         query_interface.save(path, file_format="donkey")
 
@@ -85,7 +82,7 @@ def test_query_interface_processed(
     query_interface = QueryInterfaceProcessed(database, query, lambda x: x)
     query_interface.run()
 
-    query_interface.data = test_data
+    query_interface._data = test_data  # pylint: disable=protected-access
     path = os.path.join("test_save", "test_features.parquet")
     query_interface.save(path)
     loaded_data = pd.read_parquet(path)

--- a/tests/cyclops/query/test_omop.py
+++ b/tests/cyclops/query/test_omop.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import cyclops.query.ops as qo
 from cyclops.query.omop import OMOPQuerier
 
 
@@ -9,16 +10,27 @@ from cyclops.query.omop import OMOPQuerier
 def test_omop_querier_synthea():
     """Test OMOPQuerier on synthea data."""
     synthea = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
-    visits = synthea.visit_occurrence().run()
-    persons = synthea.person().run()
+    ops = qo.Sequential(
+        [
+            qo.ConditionEquals("gender_source_value", "M"),
+            qo.Rename({"race_source_value": "race"}),
+        ]
+    )
+    persons_qi = synthea.person(ops=ops)
+    visits = synthea.visit_occurrence(
+        join=qo.JoinArgs(join_table=persons_qi.query, on="person_id")
+    ).run()
+    persons = persons_qi.run()
     observations = synthea.observation().run()
     measurements = synthea.measurement().run()
     visit_details = synthea.visit_detail().run()
-    assert len(visits) == 4115
+    providers = synthea.provider().run()
+    assert len(persons) == 54
+    assert len(visits) == 1620
     assert len(visit_details) == 4115
-    assert len(persons) == 109
     assert len(observations) == 16169
     assert len(measurements) == 19373
+    assert len(providers) == 212
 
 
 @pytest.mark.integration_test

--- a/tests/cyclops/query/test_omop.py
+++ b/tests/cyclops/query/test_omop.py
@@ -24,7 +24,7 @@ def test_omop_querier_synthea():
     observations = synthea.observation().run()
     measurements = synthea.measurement().run()
     visit_details = synthea.visit_detail().run()
-    providers = synthea.provider().run()
+    providers = synthea.provider().run()  # pylint: disable=no-member
     assert len(persons) == 54
     assert len(visits) == 1620
     assert len(visit_details) == 4115

--- a/tests/cyclops/query/test_ops.py
+++ b/tests/cyclops/query/test_ops.py
@@ -1,7 +1,9 @@
 """Test low-level query API processing functions."""
 
+from math import isclose
+
 import pytest
-from sqlalchemy import column, func, select
+from sqlalchemy import column, select
 
 from cyclops.query.omop import OMOPQuerier
 from cyclops.query.ops import (
@@ -19,6 +21,7 @@ from cyclops.query.ops import (
     OrderBy,
     Rename,
     ReorderAfter,
+    Sequential,
     Substring,
     Trim,
     _none_add,
@@ -27,12 +30,26 @@ from cyclops.query.ops import (
 )
 from cyclops.query.util import process_column
 
+SYNTHEA = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
+
 
 @pytest.fixture
-def test_table():
+def table_input():
     """Test table input."""
     column_a = process_column(column("a"), to_timestamp=True)
     return select(column_a, column("b"), column("c"))
+
+
+@pytest.fixture
+def visits_input():
+    """Test visits table input."""
+    return SYNTHEA.visit_occurrence().query
+
+
+@pytest.fixture
+def measurements_input():
+    """Test measurement table input."""
+    return SYNTHEA.measurement().query
 
 
 def test__none_add():
@@ -49,14 +66,14 @@ def test_qap():
     assert isinstance(test_arg, int) and test_arg == 2
 
 
-def test__process_checks(test_table):  # pylint: disable=redefined-outer-name
+def test__process_checks(table_input):  # pylint: disable=redefined-outer-name
     """Test _process_checks fn."""
-    _process_checks(test_table, cols=["a"], cols_not_in=["d"], timestamp_cols=["a"])
+    _process_checks(table_input, cols=["a"], cols_not_in=["d"], timestamp_cols=["a"])
     with pytest.raises(ValueError):
-        _process_checks(test_table, cols_not_in=["a"])
+        _process_checks(table_input, cols_not_in=["a"])
 
 
-def test_process_operations(test_table):  # pylint: disable=redefined-outer-name
+def test_process_operations(table_input):  # pylint: disable=redefined-outer-name
     """Test process_operations fn."""
     process_kwargs = {"b_args": "cat", "c_args": ["dog"]}
     operations = [
@@ -67,97 +84,183 @@ def test_process_operations(test_table):  # pylint: disable=redefined-outer-name
         ),
         (ConditionSubstring, ["c", QAP("c_args")], {}),
     ]
-    table = process_operations(test_table, operations, process_kwargs)
+    table = process_operations(table_input, operations, process_kwargs)
     query_lines = str(table).splitlines()
     assert query_lines[0] == "SELECT anon_1.a, anon_1.b, anon_1.c "
     assert query_lines[-1] == "WHERE lower(CAST(anon_1.c AS VARCHAR)) LIKE :lower_1"
 
 
 @pytest.mark.integration_test
-def test_operations():
-    """Test query operations."""
-    synthea = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
-    visits = synthea.visit_occurrence().query
-    measurements = synthea.measurement().query
+def test_drop(visits_input):  # pylint: disable=redefined-outer-name
+    """Test Drop."""
+    visits = Drop("care_site_source_value")(visits_input)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert "care_site_source_value" not in visits.columns
 
-    # Query operations.
-    visits = Drop("care_site_source_value")(visits)
-    visits = Rename({"care_site_name": "hospital_name"})(visits)
-    visits = Literal(1, "new_col")(visits)
-    visits = Literal("test ", "untrimmed_col")(visits)
-    visits = Substring("visit_concept_name", 0, 6, "visit_concept_name_substr")(visits)
-    visits = ReorderAfter("visit_concept_name", "care_site_id")(visits)
-    visits = Trim("untrimmed_col", "trimmed_col")(visits)
-    visits = ExtractTimestampComponent("visit_start_datetime", "year", "visit_year")(
-        visits
+
+@pytest.mark.integration_test
+def test_rename(visits_input):  # pylint: disable=redefined-outer-name
+    """Test Rename."""
+    visits = Rename({"care_site_name": "hospital_name"})(visits_input)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert "hospital_name" in visits.columns
+    assert "care_site_name" not in visits.columns
+
+
+@pytest.mark.integration_test
+def test_literal(visits_input):  # pylint: disable=redefined-outer-name
+    """Test Literal."""
+    visits = Literal(1, "new_col")(visits_input)
+    visits = Literal("a", "new_col2")(visits)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert "new_col" in visits.columns
+    assert visits["new_col"].iloc[0] == 1
+    assert "new_col2" in visits.columns
+    assert visits["new_col2"].iloc[0] == "a"
+
+
+@pytest.mark.integration_test
+def test_reorder_after(visits_input):  # pylint: disable=redefined-outer-name
+    """Test ReorderAfter."""
+    visits = ReorderAfter("visit_concept_name", "care_site_id")(visits_input)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert list(visits.columns).index("care_site_id") + 1 == list(visits.columns).index(
+        "visit_concept_name"
     )
-    visits = AddNumeric("new_col", 2, "new_col_add")(visits)
-    visits_ordered = OrderBy("person_id", ascending=True)(visits)
-    visits_limited = Limit(100)(visits)
-    visits_agg_count = GroupByAggregate(
-        "person_id", {"person_id": ("count", "visit_count")}
-    )(visits)
+
+
+@pytest.mark.integration_test
+def test_limit(visits_input):  # pylint: disable=redefined-outer-name
+    """Test Limit."""
+    visits = Limit(10)(visits_input)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert len(visits) == 10
+
+
+@pytest.mark.integration_test
+def test_order_by(visits_input):  # pylint: disable=redefined-outer-name
+    """Test OrderBy."""
+    visits = OrderBy("visit_concept_name")(visits_input)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert visits["visit_concept_name"].is_monotonic_increasing
+
+
+@pytest.mark.integration_test
+def test_substring(visits_input):  # pylint: disable=redefined-outer-name
+    """Test Substring."""
+    visits = Substring("visit_concept_name", 0, 3, "visit_concept_name_substr")(
+        visits_input
+    )
+    visits = SYNTHEA.get_interface(visits).run()
+    assert visits["visit_concept_name_substr"].iloc[0] == "In"
+
+
+@pytest.mark.integration_test
+def test_trim(visits_input):  # pylint: disable=redefined-outer-name
+    """Test Trim."""
+    visits = Trim("visit_concept_name", "visit_concept_name_trim")(visits_input)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert visits["visit_concept_name_trim"].iloc[0] == "Inpatient Visit"
+
+
+@pytest.mark.integration_test
+def test_extract_timestamp_component(
+    visits_input,
+):  # pylint: disable=redefined-outer-name
+    """Test ExtractTimestampComponent."""
+    visits = ExtractTimestampComponent(
+        "visit_start_date", "year", "visit_start_date_year"
+    )(visits_input)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert visits["visit_start_date_year"].iloc[0] == 2018
+
+
+@pytest.mark.integration_test
+def test_add_numeric(visits_input):  # pylint: disable=redefined-outer-name
+    """Test AddNumeric."""
+    visits = Literal(1, "new_col")(visits_input)
+    visits = AddNumeric("new_col", 1, "new_col_plus_1")(visits)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert visits["new_col_plus_1"].iloc[0] == 2
+
+
+@pytest.mark.integration_test
+def test_apply(visits_input):  # pylint: disable=redefined-outer-name
+    """Test Apply."""
+    visits = Apply(
+        "visit_concept_name", lambda x: x + "!", "visit_concept_name_exclaim"
+    )(visits_input)
+    visits = SYNTHEA.get_interface(visits).run()
+    assert visits["visit_concept_name_exclaim"].iloc[0] == "Inpatient Visit!"
+
+
+@pytest.mark.integration_test
+def test_condition_regex_match(
+    measurements_input,
+):  # pylint: disable=redefined-outer-name
+    """Test ConditionRegexMatch."""
+    measurements = ConditionRegexMatch(
+        "value_source_value",
+        r"^[0-9]+(\.[0-9]+)?$",
+        binarize_col="value_source_value_match",
+    )(measurements_input)
+    measurements = SYNTHEA.get_interface(measurements).run()
+    assert "value_source_value_match" in measurements.columns
+    assert (
+        measurements["value_source_value_match"].sum()
+        == measurements["value_source_value"].str.match(r"^[0-9]+(\.[0-9]+)?$").sum()
+    )
+
+
+@pytest.mark.integration_test
+def test_group_by_aggregate(  # pylint: disable=redefined-outer-name
+    visits_input, measurements_input
+):
+    """Test GroupByAggregate."""
+    with pytest.raises(ValueError):
+        GroupByAggregate("person_id", {"person_id": ("donkey", "visit_count")})(
+            visits_input
+        )
+    with pytest.raises(ValueError):
+        GroupByAggregate("person_id", {"person_id": ("count", "person_id")})(
+            visits_input
+        )
+
+    visits_count = GroupByAggregate(
+        "person_id", {"person_id": ("count", "num_visits")}
+    )(visits_input)
     visits_string_agg = GroupByAggregate(
         "person_id",
         {"visit_concept_name": ("string_agg", "visit_concept_names")},
         {"visit_concept_name": ", "},
-    )(visits)
-    visits_apply = Apply(
-        "visit_concept_name",
-        func.lower,
-        "visit_concept_name_lower",
-    )(visits)
-    with pytest.raises(ValueError):
-        visits_agg_count = GroupByAggregate(
-            "person_id", {"person_id": ("donkey", "visit_count")}
-        )(visits)
-    with pytest.raises(ValueError):
-        visits_agg_count = GroupByAggregate(
-            "person_id", {"person_id": ("count", "person_id")}
-        )(visits)
-    visits_agg_median = GroupByAggregate(
-        "person_id", {"visit_concept_name": ("median", "visit_concept_name_median")}
-    )(visits)
-    visits_regex_match = ConditionRegexMatch(
-        "visit_concept_name", r"^In?", binarize_col="visit_concept_name_match"
-    )(visits)
-    measurements_regex_match = ConditionRegexMatch(
-        "value_source_value",
-        r"^[0-9]+(\.[0-9]+)?$",
-        binarize_col="value_source_value_match",
-    )(measurements)
+    )(visits_input)
+    measurements_sum = GroupByAggregate(
+        "person_id", {"value_as_number": ("sum", "value_as_number_sum")}
+    )(measurements_input)
+    measurements_average = GroupByAggregate(
+        "person_id", {"value_as_number": ("average", "value_as_number_average")}
+    )(measurements_input)
+    measurements_min = GroupByAggregate(
+        "person_id", {"value_as_number": ("min", "value_as_number_min")}
+    )(measurements_input)
+    measurements_max = GroupByAggregate(
+        "person_id", {"value_as_number": ("max", "value_as_number_max")}
+    )(measurements_input)
+    measurements_median = GroupByAggregate(
+        "person_id", {"value_as_number": ("median", "value_as_number_median")}
+    )(measurements_input)
 
-    # Run queries.
-    visits_agg_count = synthea.get_interface(visits_agg_count).run()
-    visits_agg_median = synthea.get_interface(visits_agg_median).run()
-    visits = synthea.get_interface(visits).run()
-    visits_ordered = synthea.get_interface(visits_ordered).run()
-    visits_limited = synthea.get_interface(visits_limited).run()
-    visits_string_agg = synthea.get_interface(visits_string_agg).run()
-    visits_apply = synthea.get_interface(visits_apply).run()
-    visits_regex_match = synthea.get_interface(visits_regex_match).run()
-    measurements_regex_match = synthea.get_interface(measurements_regex_match).run()
+    visits_count = SYNTHEA.get_interface(visits_count).run()
+    visits_string_agg = SYNTHEA.get_interface(visits_string_agg).run()
+    measurements_sum = SYNTHEA.get_interface(measurements_sum).run()
+    measurements_average = SYNTHEA.get_interface(measurements_average).run()
+    measurements_min = SYNTHEA.get_interface(measurements_min).run()
+    measurements_max = SYNTHEA.get_interface(measurements_max).run()
+    measurements_median = SYNTHEA.get_interface(measurements_median).run()
 
-    # Check results.
-    assert "care_site_source_value" not in visits.columns
-    assert "care_site_name" not in visits.columns
-    assert "hospital_name" in visits.columns
-    assert "new_col" in visits.columns
-    assert visits["new_col"].unique() == 1
-    assert (
-        visits["visit_concept_name_substr"].unique() == ["Inpat", "Outpa", "Emerg"]
-    ).all()
-    assert (
-        visits.columns[list(visits.columns).index("care_site_id") + 1]
-        == "visit_concept_name"
-    )
-    assert visits["trimmed_col"].unique() == "test"
-    assert 2018 in visits["visit_year"]
-    assert visits["new_col_add"].unique() == 3
-    assert visits_agg_count[visits_agg_count["person_id"] == 33]["visit_count"][0] == 25
-    assert visits_agg_median["visit_concept_name_median"].value_counts()[0] == 107
-    assert visits_ordered["person_id"][0] == 1
-    assert len(visits_limited) == 100
+    assert "num_visits" in visits_count.columns
+    assert visits_count[visits_count["person_id"] == 33]["num_visits"][0] == 25
+    assert "visit_concept_names" in visits_string_agg.columns
     test_visit_concept_names = visits_string_agg[visits_string_agg["person_id"] == 33][
         "visit_concept_names"
     ][0].split(",")
@@ -166,16 +269,61 @@ def test_operations():
         len(test_visit_concept_names) == 25
         and "Outpatient Visit" in test_visit_concept_names
     )
+    assert "value_as_number_sum" in measurements_sum.columns
     assert (
-        visits_apply["visit_concept_name_lower"].unique()
-        == ["inpatient visit", "outpatient visit", "emergency room visit"]
-    ).all()
-    assert (
-        visits_regex_match["visit_concept_name_match"].sum()
-        == visits["visit_concept_name"].str.contains(r"In*").sum()
+        measurements_sum[measurements_sum["person_id"] == 33]["value_as_number_sum"][0]
+        == 11371.0
     )
+    assert "value_as_number_average" in measurements_average.columns
+    assert isclose(
+        measurements_average[measurements_average["person_id"] == 33][
+            "value_as_number_average"
+        ][0],
+        61.79,
+        abs_tol=0.01,
+    )
+    assert "value_as_number_min" in measurements_min.columns
     assert (
-        measurements_regex_match["value_source_value_match"].sum()
-    ) == measurements_regex_match["value_source_value"].str.contains(
-        r"^[0-9]+(\.[0-9]+)?$"
-    ).sum()
+        measurements_min[measurements_min["person_id"] == 33]["value_as_number_min"][0]
+        == 0.0
+    )
+    assert "value_as_number_max" in measurements_max.columns
+    assert (
+        measurements_max[measurements_max["person_id"] == 33]["value_as_number_max"][0]
+        == 460.9
+    )
+    assert "value_as_number_median" in measurements_median.columns
+    assert (
+        measurements_median[measurements_median["person_id"] == 33][
+            "value_as_number_median"
+        ].item()
+        == 53.1
+    )
+
+
+@pytest.mark.integration_test
+def test_sequential(visits_input):  # pylint: disable=redefined-outer-name
+    """Test Sequential."""
+    substr_op = Sequential(
+        [
+            Substring("visit_concept_name", 0, 4, "visit_concept_name_substr"),
+        ]
+    )
+    operations = [
+        Literal(33, "const"),
+        Rename({"care_site_name": "hospital_name"}),
+        Apply("visit_concept_name", lambda x: x + "!", "visit_concept_name_exclaim"),
+        OrderBy(["person_id", "visit_start_date"]),
+        substr_op,
+    ]
+    sequential_ops = Sequential(operations)
+    visits = SYNTHEA.get_interface(visits_input, ops=sequential_ops).run()
+    assert "hospital_name" in visits.columns
+    assert "visit_concept_name_exclaim" in visits.columns
+    assert list(visits[visits["person_id"] == 33]["visit_concept_name_exclaim"])[0] == (
+        "Outpatient Visit!"
+    )
+    assert "visit_concept_name_substr" in visits.columns
+    assert list(visits[visits["person_id"] == 33]["visit_concept_name_substr"])[0] == (
+        "Out"
+    )

--- a/tests/cyclops/query/test_orm.py
+++ b/tests/cyclops/query/test_orm.py
@@ -2,8 +2,8 @@
 
 import os
 
-import pytest
 import pandas as pd
+import pytest
 
 from cyclops.query import OMOPQuerier
 
@@ -13,16 +13,17 @@ def test_omop_querier():
     """Test ORM using OMOPQuerier."""
     querier = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
     assert querier is not None
-    db = querier._db
+    db_ = querier._db  # pylint: disable=protected-access
     visits_query = querier.visit_occurrence().query
-    db.save_query_to_csv(visits_query, "visits.csv")
+    db_.save_query_to_csv(visits_query, "visits.csv")
     visits_df = pd.read_csv("visits.csv")
     assert len(visits_df) == 4115
     os.remove("visits.csv")
 
-    db.save_query_to_parquet(visits_query, "visits.parquet")
+    db_.save_query_to_parquet(visits_query, "visits.parquet")
     visits_df = pd.read_parquet("visits.parquet")
     assert len(visits_df) == 4115
     os.remove("visits.parquet")
 
+    # pylint: disable=protected-access
     assert len(list(querier._db.tables(querier.schema_name))) == 44

--- a/tests/cyclops/query/test_orm.py
+++ b/tests/cyclops/query/test_orm.py
@@ -1,0 +1,28 @@
+"""Test cyclops.query.orm module."""
+
+import os
+
+import pytest
+import pandas as pd
+
+from cyclops.query import OMOPQuerier
+
+
+@pytest.mark.integration_test
+def test_omop_querier():
+    """Test ORM using OMOPQuerier."""
+    querier = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
+    assert querier is not None
+    db = querier._db
+    visits_query = querier.visit_occurrence().query
+    db.save_query_to_csv(visits_query, "visits.csv")
+    visits_df = pd.read_csv("visits.csv")
+    assert len(visits_df) == 4115
+    os.remove("visits.csv")
+
+    db.save_query_to_parquet(visits_query, "visits.parquet")
+    visits_df = pd.read_parquet("visits.parquet")
+    assert len(visits_df) == 4115
+    os.remove("visits.parquet")
+
+    assert len(list(querier._db.tables(querier.schema_name))) == 44

--- a/use_cases/data_processors/mimiciv.py
+++ b/use_cases/data_processors/mimiciv.py
@@ -1294,7 +1294,7 @@ class MIMICIVProcessor:
         cleaned_generator = self._load_batches(self.cleaned_dir)
         filter_fn = None
         if (
-            self.temp_params["query"] == mimic.EVENTS
+            self.temp_params["query"] == mimic.CHARTEVENTS
             and self.temp_params["top_n_events"]
         ):
 

--- a/use_cases/params/mimiciv/mortality_decompensation/constants.py
+++ b/use_cases/params/mimiciv/mortality_decompensation/constants.py
@@ -14,7 +14,7 @@ from cyclops.process.column_names import (
 )
 from cyclops.process.constants import ALL, MEAN, STANDARD, TARGETS
 from cyclops.process.impute import np_ffill_bfill
-from cyclops.query.mimiciv import EVENTS
+from cyclops.query.mimiciv import CHARTEVENTS
 from cyclops.utils.file import join, process_dir_save_path
 
 CONST_NAME = "mortality_decompensation"
@@ -82,7 +82,7 @@ TABULAR_AGG = {
 }
 
 TEMPORAL_PARAMS = {
-    "query": EVENTS,
+    "query": CHARTEVENTS,
     "top_n_events": 150,
     "timestep_size": 24,  # Make a prediction every day
     "window_duration": 144,  # Predict for the first 6 days of admission


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Feature/Fix

## Short Description
- Rename AddDeltaColumns to AddDeltaColumn in query ops
- Rename FilterColumns to Keep in query ops to be consistent with naming (like Drop)
- Update QueryInterface and QueryInterfaceProcessed classes to run join tables as well as chain operations to create
the final query that is run
- Update high level dataset APIs to use the join and Sequential (object) which chains a list of operations recursively. This makes code a lot cleaner. Joins are most commonly used, and hence deserve its place in the args to the dataset methods. The rest can be done using the Sequential object.
- The join is achieved by the user having to use `cyclops.query.ops.JoinArgs`, which is a dataclass.
- Create a type stub for defining a query operation (QueryOp) and use that as a metaclass for query operations.
- Remove hard coded column names in plot_timeline function in cyclops/utils/plot and instead make user specify column names.

TODO:
- [x] Still need to refactor the other dataset API modules based of this change. I only changed cyclops/query/omop.py. There is also cyclops/query/gemini.py and cyclops/query/mimiciv.py.
- [x] Add QueryOp as metaclass to all query operations.

## Tests Added
Tests updated for the modules changed.
