### PR TITLE
Add base DatasetQuerier to show up in docs

### DIFF
--- a/docs/source/reference/api/cyclops.query.rst
+++ b/docs/source/reference/api/cyclops.query.rst
@@ -10,6 +10,7 @@ cyclops.query
 
     interface
     ops
+    base
 
 dataset APIs
 ------------


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Documentation

## Short Description
Add the base DatasetQuerier class to show up in documentation, since its useful to extend to arbitrary datasets.

## Tests Added
None
