### PR TITLE
Update query API to natively query all schemas and tables

### DIFF
--- a/cyclops/query/base.py
+++ b/cyclops/query/base.py
@@ -2,21 +2,47 @@
 
 import logging
 from functools import partial
-from typing import Any, Callable, Dict, List, Mapping, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from hydra import compose, initialize
 from omegaconf import OmegaConf
+from sqlalchemy import MetaData
 from sqlalchemy.sql.selectable import Subquery
 
 from cyclops.query import ops as qo
 from cyclops.query.interface import QueryInterface, QueryInterfaceProcessed
 from cyclops.query.orm import Database
-from cyclops.query.util import DBTable, TableTypes, _to_subquery, table_params_to_type
+from cyclops.query.util import (
+    DBSchema,
+    TableTypes,
+    _to_subquery,
+    get_attr_name,
+    table_params_to_type,
+)
 from cyclops.utils.log import setup_logging
 
 # Logging.
 LOGGER = logging.getLogger(__name__)
 setup_logging(print_level="INFO", logger=LOGGER)
+
+
+def _create_get_table_lambdafn(schema_name: str, table_name: str) -> Callable[..., Any]:
+    """Create a lambda function to access a table.
+
+    Parameters
+    ----------
+    schema_name: str
+        The schema name.
+    table_name: str
+        The table name.
+
+    Returns
+    -------
+    Callable
+        The lambda function.
+
+    """
+    return lambda db: getattr(getattr(db, schema_name), table_name)
 
 
 def _cast_timestamp_cols(table: Subquery) -> Subquery:
@@ -50,30 +76,22 @@ class DatasetQuerier:
     ----------
     _db: cyclops.query.orm.Database
         ORM Database used to run queries.
-    _table_map: Mapping
-        A dictionary mapping table names to table objects in the DB.
 
     Notes
     -----
     This class is intended to be subclassed to provide methods for querying tables in
-    the database. The subclass accepts a table map as an argument, which is a mapping
-    from table names to table objects. By default, the methods are named after the
-    table names. The subclass can override the table methods by defining a method with
-    the same name as the table. The subclass can also add additional methods.
+    the database.
 
     """
 
     def __init__(
         self,
-        table_map: Mapping[str, Callable[..., DBTable]],
         **config_overrides: Dict[str, Any],
     ) -> None:
         """Initialize.
 
         Parameters
         ----------
-        table_map: Mapping
-            A dictionary mapping table names to table objects in the DB.
         **config_overrides
              Override configuration parameters, specified as kwargs.
 
@@ -88,9 +106,19 @@ class DatasetQuerier:
             config = compose(config_name="config", overrides=overrides)
             LOGGER.debug(OmegaConf.to_yaml(config))
 
-        self._db = Database(config)
-        self._table_map = table_map
+        self.db = Database(config)
         self._setup_table_methods()
+
+    def list_schemas(self) -> List[str]:
+        """List schemas in the database to query.
+
+        Returns
+        -------
+        List[str]
+            List of schema names.
+
+        """
+        return list(self.db.inspector.get_schema_names())
 
     def list_tables(self) -> List[str]:
         """List table methods that can be queried using the database.
@@ -101,7 +129,33 @@ class DatasetQuerier:
             List of table names.
 
         """
-        return list(self._table_map.keys())
+        return self.db.list_tables()
+
+    def list_custom_tables(self) -> List[str]:
+        """List custom tables methods provided by the dataset API.
+
+        Returns
+        -------
+        List[str]
+            List of custom table names.
+
+        """
+        method_list = dir(self)
+        custom_tables = []
+        for method in method_list:
+            if (
+                not method.startswith(  # pylint: disable=too-many-boolean-expressions
+                    "__"
+                )
+                and not method.startswith("_")
+                and method not in self.list_schemas()
+                and not method.startswith("list_")
+                and not method.startswith("get_")
+                and method not in ["db"]
+            ):
+                custom_tables.append(method)
+
+        return custom_tables
 
     @table_params_to_type(Subquery)
     def get_interface(
@@ -129,18 +183,22 @@ class DatasetQuerier:
 
         """
         if process_fn is None:
-            return QueryInterface(self._db, table, ops=ops)
+            return QueryInterface(self.db, table, ops=ops)
 
-        return QueryInterfaceProcessed(self._db, table, ops=ops, process_fn=process_fn)
+        return QueryInterfaceProcessed(self.db, table, ops=ops, process_fn=process_fn)
 
-    def get_table(self, table_name: str, cast_timestamp_cols: bool = True) -> Subquery:
+    def get_table(
+        self, schema_name: str, table_name: str, cast_timestamp_cols: bool = True
+    ) -> Subquery:
         """Get a table and possibly map columns to have standard names.
 
-        Standardizing column names allows for for columns to be
+        Standardizing column names allows for columns to be
         recognized in downstream processing.
 
         Parameters
         ----------
+        schema_name: str
+            Name of schema in the database.
         table_name: str
             Name of GEMINI table.
         cast_timestamp_cols: bool
@@ -152,10 +210,7 @@ class DatasetQuerier:
             Table with mapped columns.
 
         """
-        if table_name not in self._table_map:
-            raise ValueError(f"{table_name} not a recognised table.")
-
-        table = self._table_map[table_name](self._db).data
+        table = _create_get_table_lambdafn(schema_name, table_name)(self.db).data
 
         if cast_timestamp_cols:
             table = _cast_timestamp_cols(table)
@@ -164,6 +219,7 @@ class DatasetQuerier:
 
     def _template_table_method(
         self,
+        schema_name: str,
         table_name: str,
         join: Optional[qo.JoinArgs] = None,
         ops: Optional[qo.Sequential] = None,
@@ -172,6 +228,8 @@ class DatasetQuerier:
 
         Parameters
         ----------
+        schema_name: str
+            Name of schema in the database.
         table_name: str
             Name of table in the database.
         join: cyclops.query.ops.JoinArgs
@@ -185,9 +243,10 @@ class DatasetQuerier:
             A query interface object.
 
         """
-        table = self.get_table(table_name)
+        table = getattr(getattr(self.db, schema_name), table_name).data
+        table = _to_subquery(table)
 
-        return QueryInterface(self._db, table, join=join, ops=ops)
+        return QueryInterface(self.db, table, join=join, ops=ops)
 
     def _setup_table_methods(self) -> None:
         """Add table methods.
@@ -196,10 +255,21 @@ class DatasetQuerier:
         the database. The methods are named after the table names.
 
         """
-        for table_name in self._table_map:
-            if not hasattr(self, table_name):
+        schemas = self.db.inspector.get_schema_names()
+        meta: Dict[str, MetaData] = {}
+        for schema_name in schemas:
+            metadata = MetaData(schema=schema_name)
+            metadata.reflect(bind=self.db.engine)
+            meta[schema_name] = metadata
+            schema = DBSchema(schema_name, meta[schema_name])
+            for table_name in meta[schema_name].tables:
                 setattr(
-                    self,
-                    table_name,
-                    partial(self._template_table_method, table_name=table_name),
+                    schema,
+                    get_attr_name(table_name),
+                    partial(
+                        self._template_table_method,
+                        schema_name=schema_name,
+                        table_name=get_attr_name(table_name),
+                    ),
                 )
+            setattr(self, schema_name, schema)

--- a/cyclops/query/eicu.py
+++ b/cyclops/query/eicu.py
@@ -15,40 +15,6 @@ LOGGER = logging.getLogger(__name__)
 setup_logging(print_level="INFO", logger=LOGGER)
 
 
-# Constants.
-PATIENT = "patient"
-ADMISSIONDX = "admissiondx"
-DIAGNOSIS = "diagnosis"
-HOSPITAL = "hospital"
-LAB = "lab"
-MEDICATION = "medication"
-VITALPERIODIC = "vitalperiodic"
-VITALAPERIODIC = "vitalaperiodic"
-RESPIRATORYCARE = "respiratorycare"
-RESPIRATORYCHARTING = "respiratorycharting"
-INTAKEOUTPUT = "intakeoutput"
-MICROLAB = "microlab"
-TREATMENT = "treatment"
-INFUSIONDRUG = "infusiondrug"
-
-TABLE_MAP = {
-    PATIENT: lambda db: db.eicu_crd.patient,
-    ADMISSIONDX: lambda db: db.eicu_crd.admissiondx,
-    DIAGNOSIS: lambda db: db.eicu_crd.diagnosis,
-    HOSPITAL: lambda db: db.eicu_crd.hospital,
-    LAB: lambda db: db.eicu_crd.lab,
-    MEDICATION: lambda db: db.eicu_crd.medication,
-    VITALPERIODIC: lambda db: db.eicu_crd.vitalperiodic,
-    VITALAPERIODIC: lambda db: db.eicu_crd.vitalaperiodic,
-    RESPIRATORYCARE: lambda db: db.eicu_crd.respiratorycare,
-    RESPIRATORYCHARTING: lambda db: db.eicu_crd.respiratorycharting,
-    INTAKEOUTPUT: lambda db: db.eicu_crd.intakeoutput,
-    MICROLAB: lambda db: db.eicu_crd.microlab,
-    TREATMENT: lambda db: db.eicu_crd.treatment,
-    INFUSIONDRUG: lambda db: db.eicu_crd.infusiondrug,
-}
-
-
 class EICUQuerier(DatasetQuerier):
     """eICU dataset querier."""
 
@@ -64,4 +30,4 @@ class EICUQuerier(DatasetQuerier):
         overrides = {}
         if config_overrides:
             overrides = config_overrides
-        super().__init__(TABLE_MAP, **overrides)
+        super().__init__(**overrides)

--- a/cyclops/query/mimiciii.py
+++ b/cyclops/query/mimiciii.py
@@ -17,37 +17,6 @@ LOGGER = logging.getLogger(__name__)
 setup_logging(print_level="INFO", logger=LOGGER)
 
 
-# Constants.
-PATIENTS = "patients"
-ADMISSIONS = "admissions"
-DIAGNOSES_ICD = "diagnoses_icd"
-LABEVENTS = "labevents"
-CHARTEVENTS = "chartevents"
-TRANSFERS = "transfers"
-PRESCRIPTIONS = "prescriptions"
-MICROBIOLOGYEVENTS = "microbiologyevents"
-PROCEDUREEVENTS_MV = "procedureevents_mv"
-DIM_ITEMS = "dim_items"
-DIM_LABITEMS = "dim_labitems"
-DIM_ICD_DIAGNOSES = "dim_icd_diagnoses"
-
-
-TABLE_MAP = {
-    PATIENTS: lambda db: db.mimiciii.patients,
-    ADMISSIONS: lambda db: db.mimiciii.admissions,
-    DIAGNOSES_ICD: lambda db: db.mimiciii.diagnoses_icd,
-    LABEVENTS: lambda db: db.mimiciii.labevents,
-    CHARTEVENTS: lambda db: db.mimiciii.chartevents,
-    TRANSFERS: lambda db: db.mimiciii.transfers,
-    PRESCRIPTIONS: lambda db: db.mimiciii.prescriptions,
-    MICROBIOLOGYEVENTS: lambda db: db.mimiciii.microbiologyevents,
-    PROCEDUREEVENTS_MV: lambda db: db.mimiciii.procedureevents_mv,
-    DIM_LABITEMS: lambda db: db.mimiciii.d_labitems,
-    DIM_ITEMS: lambda db: db.mimiciii.d_items,
-    DIM_ICD_DIAGNOSES: lambda db: db.mimiciii.d_icd_diagnoses,
-}
-
-
 class MIMICIIIQuerier(DatasetQuerier):
     """MIMIC-III dataset querier."""
 
@@ -63,9 +32,9 @@ class MIMICIIIQuerier(DatasetQuerier):
         overrides = {}
         if config_overrides:
             overrides = config_overrides
-        super().__init__(TABLE_MAP, **overrides)
+        super().__init__(**overrides)
 
-    def diagnoses_icd(
+    def diagnoses(
         self,
         join: Optional[qo.JoinArgs] = None,
         ops: Optional[qo.Sequential] = None,
@@ -85,16 +54,16 @@ class MIMICIIIQuerier(DatasetQuerier):
             Constructed query, wrapped in an interface object.
 
         """
-        table = self.get_table(DIAGNOSES_ICD)
+        table = self.get_table("mimiciii", "diagnoses_icd")
 
         # Join with diagnoses dimension table.
         table = qo.Join(
-            join_table=self.get_table(DIM_ICD_DIAGNOSES),
+            join_table=self.get_table("mimiciii", "d_icd_diagnoses"),
             on=["icd9_code"],
             on_to_type=["str"],
         )(table)
 
-        return QueryInterface(self._db, table, join=join, ops=ops)
+        return QueryInterface(self.db, table, join=join, ops=ops)
 
     def labevents(
         self,
@@ -116,16 +85,16 @@ class MIMICIIIQuerier(DatasetQuerier):
             Constructed query, wrapped in an interface object.
 
         """
-        table = self.get_table(LABEVENTS)
+        table = self.get_table("mimiciii", "labevents")
 
         # Join with lab dimension table.
         table = qo.Join(
-            join_table=self.get_table(DIM_LABITEMS),
+            join_table=self.get_table("mimiciii", "d_labitems"),
             on=["itemid"],
             on_to_type=["str"],
         )(table)
 
-        return QueryInterface(self._db, table, join=join, ops=ops)
+        return QueryInterface(self.db, table, join=join, ops=ops)
 
     def chartevents(
         self,
@@ -147,13 +116,13 @@ class MIMICIIIQuerier(DatasetQuerier):
             Constructed query, wrapped in an interface object.
 
         """
-        table = self.get_table(CHARTEVENTS)
+        table = self.get_table("mimiciii", "chartevents")
 
         # Join with dimension table.
         table = qo.Join(
-            join_table=self.get_table(DIM_ITEMS),
+            join_table=self.get_table("mimiciii", "d_items"),
             on=["itemid"],
             on_to_type=["str"],
         )(table)
 
-        return QueryInterface(self._db, table, join=join, ops=ops)
+        return QueryInterface(self.db, table, join=join, ops=ops)

--- a/cyclops/query/mimiciv.py
+++ b/cyclops/query/mimiciv.py
@@ -21,34 +21,6 @@ LOGGER = logging.getLogger(__name__)
 setup_logging(print_level="INFO", logger=LOGGER)
 
 
-# Constants.
-PATIENTS = "patients"
-ADMISSIONS = "admissions"
-DIAGNOSES = "diagnoses"
-DIM_DIAGNOSES = "dim_diagnoses"
-DIM_ITEMS = "dim_items"
-DIM_LABITEMS = "dim_labitems"
-CHARTEVENTS = "chartevents"
-TRANSFERS = "transfers"
-PHARMACY = "pharmacy"
-LABEVENTS = "labevents"
-EDSTAYS = "ed_stays"
-
-TABLE_MAP = {
-    PATIENTS: lambda db: db.mimiciv_hosp.patients,
-    ADMISSIONS: lambda db: db.mimiciv_hosp.admissions,
-    DIAGNOSES: lambda db: db.mimiciv_hosp.diagnoses_icd,
-    DIM_DIAGNOSES: lambda db: db.mimiciv_hosp.d_icd_diagnoses,
-    DIM_LABITEMS: lambda db: db.mimiciv_hosp.d_labitems,
-    DIM_ITEMS: lambda db: db.mimiciv_icu.d_items,
-    CHARTEVENTS: lambda db: db.mimiciv_icu.chartevents,
-    LABEVENTS: lambda db: db.mimiciv_hosp.labevents,
-    PHARMACY: lambda db: db.mimiciv_hosp.pharmacy,
-    TRANSFERS: lambda db: db.mimiciv_hosp.transfers,
-    EDSTAYS: lambda db: db.mimic_ed.edstays,
-}
-
-
 class MIMICIVQuerier(DatasetQuerier):
     """MIMICIV dataset querier."""
 
@@ -64,7 +36,7 @@ class MIMICIVQuerier(DatasetQuerier):
         overrides = {}
         if config_overrides:
             overrides = config_overrides
-        super().__init__(TABLE_MAP, **overrides)
+        super().__init__(**overrides)
 
     def patients(
         self,
@@ -93,7 +65,7 @@ class MIMICIVQuerier(DatasetQuerier):
         adjusted based on the inferred approximate year of care.
 
         """
-        table = self.get_table(PATIENTS)
+        table = self.get_table("mimiciv_hosp", "patients")
 
         # Process and include patient's anchor year.
         table = select(
@@ -137,7 +109,7 @@ class MIMICIVQuerier(DatasetQuerier):
             ]
         )(table)
 
-        return QueryInterface(self._db, table, join=join, ops=ops)
+        return QueryInterface(self.db, table, join=join, ops=ops)
 
     def diagnoses(
         self,
@@ -159,16 +131,16 @@ class MIMICIVQuerier(DatasetQuerier):
             Constructed query, wrapped in an interface object.
 
         """
-        table = self.get_table(DIAGNOSES)
+        table = self.get_table("mimiciv_hosp", "diagnoses_icd")
 
         # Join with diagnoses dimension table.
         table = qo.Join(
-            join_table=self.get_table(DIM_DIAGNOSES),
+            join_table=self.get_table("mimiciv_hosp", "d_icd_diagnoses"),
             on=["icd_code", "icd_version"],
             on_to_type=["str", "int"],
         )(table)
 
-        return QueryInterface(self._db, table, join=join, ops=ops)
+        return QueryInterface(self.db, table, join=join, ops=ops)
 
     def care_units(
         self, join: Optional[qo.JoinArgs] = None, ops: Optional[qo.Sequential] = None
@@ -188,9 +160,9 @@ class MIMICIVQuerier(DatasetQuerier):
             Constructed table, wrapped in an interface object.
 
         """
-        table = self.get_table(TRANSFERS)
+        table = self.get_table("mimiciv_hosp", "transfers")
         return QueryInterfaceProcessed(
-            self._db,
+            self.db,
             table,
             process_fn=lambda x: process_mimic_care_units(x, specific=False),
             join=join,
@@ -215,8 +187,8 @@ class MIMICIVQuerier(DatasetQuerier):
             Constructed query, wrapped in an interface object.
 
         """
-        table = self.get_table(LABEVENTS)
-        dim_items_table = self.get_table(DIM_LABITEMS)
+        table = self.get_table("mimiciv_hosp", "labevents")
+        dim_items_table = self.get_table("mimiciv_hosp", "d_labitems")
 
         # Join with lab items dimension table.
         table = qo.Join(
@@ -224,7 +196,7 @@ class MIMICIVQuerier(DatasetQuerier):
             on=["itemid"],
         )(table)
 
-        return QueryInterface(self._db, table, join=join, ops=ops)
+        return QueryInterface(self.db, table, join=join, ops=ops)
 
     def chartevents(
         self, join: Optional[qo.JoinArgs] = None, ops: Optional[qo.Sequential] = None
@@ -244,8 +216,8 @@ class MIMICIVQuerier(DatasetQuerier):
             Constructed table, wrapped in an interface object.
 
         """
-        table = self.get_table(CHARTEVENTS)
-        dim_items_table = self.get_table(DIM_ITEMS)
+        table = self.get_table("mimiciv_icu", "chartevents")
+        dim_items_table = self.get_table("mimiciv_icu", "d_items")
 
         # Join with items dimension table.
         table = qo.Join(
@@ -253,4 +225,4 @@ class MIMICIVQuerier(DatasetQuerier):
             on="itemid",
         )(table)
 
-        return QueryInterface(self._db, table, join=join, ops=ops)
+        return QueryInterface(self.db, table, join=join, ops=ops)

--- a/cyclops/query/util.py
+++ b/cyclops/query/util.py
@@ -27,6 +27,11 @@ setup_logging(print_level="INFO", logger=LOGGER)
 COLUMN_OBJECTS = [Column, ColumnClause]
 
 
+def get_attr_name(name: str) -> str:
+    """Get attribute name (second part of first.second)."""
+    return name.split(".")[-1]
+
+
 @dataclass
 class DBSchema:
     """Database schema wrapper.

--- a/docs/source/tutorials/eicu/query_api.ipynb
+++ b/docs/source/tutorials/eicu/query_api.ipynb
@@ -39,26 +39,50 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-02-22 16:04:49,072 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
+      "2023-03-21 11:15:50,751 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['patient',\n",
-       " 'admissiondx',\n",
-       " 'diagnosis',\n",
-       " 'hospital',\n",
-       " 'lab',\n",
-       " 'medication',\n",
-       " 'vitalperiodic',\n",
-       " 'vitalaperiodic',\n",
-       " 'respiratorycare',\n",
-       " 'respiratorycharting',\n",
-       " 'intakeoutput',\n",
-       " 'microlab',\n",
-       " 'treatment',\n",
-       " 'infusiondrug']"
+       "['eicu_crd.admissiondrug',\n",
+       " 'eicu_crd.admissiondx',\n",
+       " 'eicu_crd.allergy',\n",
+       " 'eicu_crd.apacheapsvar',\n",
+       " 'eicu_crd.apachepatientresult',\n",
+       " 'eicu_crd.apachepredvar',\n",
+       " 'eicu_crd.careplancareprovider',\n",
+       " 'eicu_crd.careplaneol',\n",
+       " 'eicu_crd.careplangeneral',\n",
+       " 'eicu_crd.careplangoal',\n",
+       " 'eicu_crd.careplaninfectiousdisease',\n",
+       " 'eicu_crd.customlab',\n",
+       " 'eicu_crd.diagnosis',\n",
+       " 'eicu_crd.hospital',\n",
+       " 'eicu_crd.infusiondrug',\n",
+       " 'eicu_crd.intakeoutput',\n",
+       " 'eicu_crd.lab',\n",
+       " 'eicu_crd.medication',\n",
+       " 'eicu_crd.microlab',\n",
+       " 'eicu_crd.note',\n",
+       " 'eicu_crd.nurseassessment',\n",
+       " 'eicu_crd.nursecare',\n",
+       " 'eicu_crd.nursecharting',\n",
+       " 'eicu_crd.pasthistory',\n",
+       " 'eicu_crd.patient',\n",
+       " 'eicu_crd.physicalexam',\n",
+       " 'eicu_crd.respiratorycare',\n",
+       " 'eicu_crd.respiratorycharting',\n",
+       " 'eicu_crd.treatment',\n",
+       " 'eicu_crd.vitalaperiodic',\n",
+       " 'eicu_crd.vitalperiodic',\n",
+       " 'information_schema.sql_packages',\n",
+       " 'information_schema.sql_features',\n",
+       " 'information_schema.sql_implementation_info',\n",
+       " 'information_schema.sql_parts',\n",
+       " 'information_schema.sql_languages',\n",
+       " 'information_schema.sql_sizing',\n",
+       " 'information_schema.sql_sizing_profiles']"
       ]
      },
      "execution_count": 1,
@@ -70,7 +94,7 @@
     "import cyclops.query.ops as qo\n",
     "from cyclops.query import EICUQuerier\n",
     "\n",
-    "eicu = EICUQuerier(\n",
+    "querier = EICUQuerier(\n",
     "    dbms=\"postgresql\",\n",
     "    port=5432,\n",
     "    host=\"localhost\",\n",
@@ -79,7 +103,7 @@
     "    password=\"pwd\",\n",
     ")\n",
     "# List all tables.\n",
-    "eicu.list_tables()"
+    "querier.list_tables()"
    ]
   },
   {
@@ -102,8 +126,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-02-22 16:04:49,822 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-02-22 16:04:49,823 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.737342 s\n"
+      "2023-03-21 11:15:52,228 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:15:52,229 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.704464 s\n"
      ]
     },
     {
@@ -121,7 +145,7 @@
     "        qo.ConditionEquals(\"gender\", \"Female\"),\n",
     "    ]\n",
     ")\n",
-    "patients = eicu.patient(ops=ops).run()\n",
+    "patients = querier.eicu_crd.patient(ops=ops).run()\n",
     "print(f\"{len(patients)} rows extracted!\")"
    ]
   },
@@ -147,8 +171,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-02-22 16:04:51,493 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-02-22 16:04:51,493 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.521227 s\n"
+      "2023-03-21 11:15:53,069 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:15:53,070 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.787358 s\n"
      ]
     },
     {
@@ -165,13 +189,13 @@
     "        qo.ConditionEquals(\"hospitaldischargeyear\", 2015),\n",
     "    ]\n",
     ")\n",
-    "patients = eicu.patient(ops=ops)\n",
+    "patients = querier.eicu_crd.patient(ops=ops)\n",
     "diagnosis_ops = qo.Sequential(\n",
     "    [\n",
     "        qo.ConditionSubstring(\"diagnosisstring\", \"schizophrenia\"),\n",
     "    ]\n",
     ")\n",
-    "diagnoses = eicu.diagnosis(\n",
+    "diagnoses = querier.eicu_crd.diagnosis(\n",
     "    join=qo.JoinArgs(\n",
     "        join_table=patients.query,\n",
     "        on=\"patientunitstayid\",\n",
@@ -201,8 +225,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-02-22 16:05:05,321 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-02-22 16:05:05,322 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 13.692760 s\n"
+      "2023-03-21 11:16:03,196 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:16:03,197 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 9.992888 s\n"
      ]
     },
     {
@@ -214,14 +238,14 @@
     }
    ],
    "source": [
-    "hospitals = eicu.hospital()\n",
+    "hospitals = querier.eicu_crd.hospital()\n",
     "ops = qo.Sequential(\n",
     "    [\n",
     "        qo.ConditionEquals(\"hospitaldischargeyear\", 2015),\n",
     "        qo.ConditionEquals(\"teachingstatus\", True),\n",
     "    ]\n",
     ")\n",
-    "patients = eicu.patient(\n",
+    "patients = querier.eicu_crd.patient(\n",
     "    join=qo.JoinArgs(join_table=hospitals.query, on=\"hospitalid\"), ops=ops\n",
     ")\n",
     "lab_ops = qo.Sequential(\n",
@@ -229,7 +253,7 @@
     "        qo.ConditionEquals(\"labname\", \"potassium\"),\n",
     "    ]\n",
     ")\n",
-    "labs = eicu.lab(\n",
+    "labs = querier.eicu_crd.lab(\n",
     "    join=qo.JoinArgs(\n",
     "        join_table=patients.query,\n",
     "        on=\"patientunitstayid\",\n",
@@ -249,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "f6142f27-e8d1-453c-bfe2-2265d9ff1914",
    "metadata": {
     "tags": []
@@ -259,8 +283,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-02-22 16:05:20,953 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-02-22 16:05:20,955 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.328528 s\n"
+      "2023-03-21 11:16:05,470 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:16:05,471 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 2.221213 s\n"
      ]
     },
     {
@@ -278,13 +302,13 @@
     "        qo.ConditionEquals(\"gender\", \"Female\"),\n",
     "    ]\n",
     ")\n",
-    "patients = eicu.patient(ops=ops)\n",
+    "patients = querier.eicu_crd.patient(ops=ops)\n",
     "medications_ops = qo.Sequential(\n",
     "    [\n",
     "        qo.ConditionSubstring(\"drugname\", \"glucose\"),\n",
     "    ]\n",
     ")\n",
-    "medications = eicu.medication(\n",
+    "medications = querier.eicu_crd.medication(\n",
     "    join=qo.JoinArgs(join_table=patients.query, on=\"patientunitstayid\"),\n",
     "    ops=medications_ops,\n",
     ").run()\n",

--- a/docs/source/tutorials/mimiciii/query_api.ipynb
+++ b/docs/source/tutorials/mimiciii/query_api.ipynb
@@ -39,24 +39,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-07 12:53:36,501 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
+      "2023-03-21 11:28:38,632 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['patients',\n",
-       " 'admissions',\n",
-       " 'diagnoses_icd',\n",
-       " 'labevents',\n",
-       " 'chartevents',\n",
-       " 'transfers',\n",
-       " 'prescriptions',\n",
-       " 'microbiologyevents',\n",
-       " 'procedureevents_mv',\n",
-       " 'dim_labitems',\n",
-       " 'dim_items',\n",
-       " 'dim_icd_diagnoses']"
+       "['chartevents', 'diagnoses', 'labevents']"
       ]
      },
      "execution_count": 1,
@@ -68,7 +57,7 @@
     "import cyclops.query.ops as qo\n",
     "from cyclops.query import MIMICIIIQuerier\n",
     "\n",
-    "mimic = MIMICIIIQuerier(\n",
+    "querier = MIMICIIIQuerier(\n",
     "    dbms=\"postgresql\",\n",
     "    port=5432,\n",
     "    host=\"localhost\",\n",
@@ -76,8 +65,8 @@
     "    user=\"postgres\",\n",
     "    password=\"pwd\",\n",
     ")\n",
-    "# List all tables.\n",
-    "mimic.list_tables()"
+    "# List all custom table methods.\n",
+    "querier.list_custom_tables()"
    ]
   },
   {
@@ -100,8 +89,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-07 12:53:37,064 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-03-07 12:53:37,065 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.535097 s\n"
+      "2023-03-21 11:28:42,421 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:28:42,422 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.199767 s\n"
      ]
     },
     {
@@ -119,7 +108,7 @@
     "        qo.ConditionEquals(\"gender\", \"M\"),\n",
     "    ]\n",
     ")\n",
-    "patients = mimic.patients(ops=ops).run()\n",
+    "patients = querier.mimiciii.patients(ops=ops).run()\n",
     "print(f\"{len(patients)} rows extracted!\")"
    ]
   },
@@ -145,8 +134,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-07 12:54:04,751 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-03-07 12:54:04,752 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 26.071373 s\n"
+      "2023-03-21 11:28:45,673 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:28:45,674 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.412656 s\n"
      ]
     },
     {
@@ -168,11 +157,11 @@
     "        qo.ConditionSubstring(\"long_title\", \"gastroenteritis\"),\n",
     "    ]\n",
     ")\n",
-    "patients = mimic.patients(ops=ops)\n",
-    "admissions = mimic.admissions(\n",
+    "patients = querier.mimiciii.patients(ops=ops)\n",
+    "admissions = querier.mimiciii.admissions(\n",
     "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
     ")\n",
-    "diagnoses = mimic.diagnoses_icd(\n",
+    "diagnoses = querier.diagnoses(\n",
     "    join=qo.JoinArgs(\n",
     "        join_table=admissions.query,\n",
     "        on=[\"subject_id\", \"hadm_id\"],\n",
@@ -202,8 +191,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-07 12:54:31,969 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-03-07 12:54:31,970 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 27.185277 s\n"
+      "2023-03-21 11:29:21,793 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:29:21,793 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 36.105737 s\n"
      ]
     },
     {
@@ -220,13 +209,13 @@
     "        qo.ConditionEquals(\"gender\", \"F\"),\n",
     "    ]\n",
     ")\n",
-    "patients = mimic.patients(ops=ops)\n",
+    "patients = querier.mimiciii.patients(ops=ops)\n",
     "lab_ops = qo.Sequential(\n",
     "    [\n",
     "        qo.ConditionEquals(\"label\", \"potassium\"),\n",
     "    ]\n",
     ")\n",
-    "labs = mimic.labevents(ops=lab_ops).run()\n",
+    "labs = querier.labevents(ops=lab_ops).run()\n",
     "print(f\"{len(labs)} rows extracted!\")"
    ]
   },
@@ -250,8 +239,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-07 12:55:54,659 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-03-07 12:55:54,660 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 82.670165 s\n"
+      "2023-03-21 11:30:55,269 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:30:55,270 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 93.461851 s\n"
      ]
     },
     {
@@ -275,8 +264,8 @@
     "        qo.ConditionLessThan(\"valuenum\", 20),\n",
     "    ]\n",
     ")\n",
-    "patients = mimic.patients(ops=ops)\n",
-    "chart_events = mimic.chartevents(ops=chartevents_ops).run()\n",
+    "patients = querier.mimiciii.patients(ops=ops)\n",
+    "chart_events = querier.chartevents(ops=chartevents_ops).run()\n",
     "print(f\"{len(chart_events)} rows extracted!\")"
    ]
   }

--- a/docs/source/tutorials/mimiciv/query_api.ipynb
+++ b/docs/source/tutorials/mimiciv/query_api.ipynb
@@ -31,29 +31,29 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "53009e6b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-30 15:16:11,459 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
+      "2023-03-21 10:55:19,273 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['patients',\n",
-       " 'admissions',\n",
-       " 'diagnoses',\n",
-       " 'dim_diagnoses',\n",
-       " 'dim_labitems',\n",
-       " 'dim_items',\n",
-       " 'chartevents',\n",
-       " 'labevents',\n",
-       " 'pharmacy',\n",
-       " 'transfers',\n",
-       " 'ed_stays']"
+       "['fhir_etl',\n",
+       " 'fhir_trm',\n",
+       " 'information_schema',\n",
+       " 'mimic_fhir',\n",
+       " 'mimiciv_derived',\n",
+       " 'mimiciv_ed',\n",
+       " 'mimiciv_hosp',\n",
+       " 'mimiciv_icu',\n",
+       " 'public']"
       ]
      },
      "execution_count": 1,
@@ -65,7 +65,7 @@
     "import cyclops.query.ops as qo\n",
     "from cyclops.query import MIMICIVQuerier\n",
     "\n",
-    "mimic = MIMICIVQuerier(\n",
+    "querier = MIMICIVQuerier(\n",
     "    dbms=\"postgresql\",\n",
     "    port=5432,\n",
     "    host=\"localhost\",\n",
@@ -73,8 +73,8 @@
     "    user=\"postgres\",\n",
     "    password=\"pwd\",\n",
     ")\n",
-    "# List all tables.\n",
-    "mimic.list_tables()"
+    "# List all schemas.\n",
+    "querier.list_schemas()"
    ]
   },
   {
@@ -97,8 +97,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-30 15:16:11,879 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-30 15:16:11,880 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.284805 s\n"
+      "2023-03-21 10:55:22,420 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 10:55:22,421 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.457140 s\n"
      ]
     },
     {
@@ -110,14 +110,14 @@
     }
    ],
    "source": [
-    "patients = mimic.patients()\n",
+    "patients = querier.patients()\n",
     "ops = qo.Sequential(\n",
     "    [\n",
     "        qo.AddDeltaColumn([\"admittime\", \"dischtime\"], years=\"anchor_year_difference\"),\n",
     "        qo.ConditionAfterDate(\"admittime\", \"2021-01-01\"),\n",
     "    ]\n",
     ")\n",
-    "admissions = mimic.admissions(\n",
+    "admissions = querier.mimiciv_hosp.admissions(\n",
     "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
     "    ops=ops,\n",
     ").run()\n",
@@ -142,8 +142,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-30 15:16:12,872 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-30 15:16:12,873 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.874558 s\n"
+      "2023-03-21 10:55:23,381 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 10:55:23,382 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.851405 s\n"
      ]
     },
     {
@@ -167,12 +167,12 @@
     "        qo.ConditionInYears(\"admittime\", \"2015\"),\n",
     "    ]\n",
     ")\n",
-    "patients = mimic.patients()\n",
-    "admissions = mimic.admissions(\n",
+    "patients = querier.patients()\n",
+    "admissions = querier.mimiciv_hosp.admissions(\n",
     "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
     "    ops=admissions_ops,\n",
     ")\n",
-    "diagnoses = mimic.diagnoses(\n",
+    "diagnoses = querier.diagnoses(\n",
     "    join=qo.JoinArgs(\n",
     "        join_table=admissions.query,\n",
     "        on=[\"subject_id\", \"hadm_id\"],\n",
@@ -200,8 +200,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-30 15:16:14,524 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-30 15:16:14,525 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.533797 s\n"
+      "2023-03-21 10:55:25,071 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 10:55:25,072 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.487202 s\n"
      ]
     },
     {
@@ -225,12 +225,12 @@
     "        qo.ConditionRegexMatch(\"long_title\", r\"(?=.*schizophrenia)(?=.*chronic)\"),\n",
     "    ]\n",
     ")\n",
-    "patients = mimic.patients()\n",
-    "admissions = mimic.admissions(\n",
+    "patients = querier.patients()\n",
+    "admissions = querier.mimiciv_hosp.admissions(\n",
     "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
     "    ops=admissions_ops,\n",
     ")\n",
-    "diagnoses = mimic.diagnoses(\n",
+    "diagnoses = querier.diagnoses(\n",
     "    join=qo.JoinArgs(\n",
     "        join_table=admissions.query,\n",
     "        on=[\"subject_id\", \"hadm_id\"],\n",
@@ -258,8 +258,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-30 15:17:49,765 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-30 15:17:49,765 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 95.007937 s\n"
+      "2023-03-21 10:56:48,290 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 10:56:48,292 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 83.105180 s\n"
      ]
     },
     {
@@ -278,12 +278,12 @@
     "    ]\n",
     ")\n",
     "chartevents_ops = qo.Sequential([qo.ConditionEquals(\"category\", \"Routine Vital Signs\")])\n",
-    "patients = mimic.patients()\n",
-    "admissions = mimic.admissions(\n",
+    "patients = querier.patients()\n",
+    "admissions = querier.mimiciv_hosp.admissions(\n",
     "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
     "    ops=admissions_ops,\n",
     ")\n",
-    "vitals = mimic.chartevents(\n",
+    "vitals = querier.chartevents(\n",
     "    join=qo.JoinArgs(\n",
     "        join_table=admissions.query,\n",
     "        on=[\"subject_id\", \"hadm_id\"],\n",
@@ -311,8 +311,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-30 15:19:03,562 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-30 15:19:03,563 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 73.678148 s\n"
+      "2023-03-21 10:58:00,473 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 10:58:00,476 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 72.076855 s\n"
      ]
     },
     {
@@ -331,12 +331,12 @@
     "    ]\n",
     ")\n",
     "labevents_ops = qo.Sequential([qo.ConditionEquals(\"label\", \"hemoglobin\")])\n",
-    "patients = mimic.patients()\n",
-    "admissions = mimic.admissions(\n",
+    "patients = querier.patients()\n",
+    "admissions = querier.mimiciv_hosp.admissions(\n",
     "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
     "    ops=admissions_ops,\n",
     ")\n",
-    "labs = mimic.chartevents(\n",
+    "labs = querier.chartevents(\n",
     "    join=qo.JoinArgs(\n",
     "        join_table=admissions.query,\n",
     "        on=[\"subject_id\", \"hadm_id\"],\n",
@@ -364,8 +364,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-30 15:19:04,056 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-30 15:19:04,057 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.442855 s\n"
+      "2023-03-21 10:58:01,003 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 10:58:01,004 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.465366 s\n"
      ]
     },
     {
@@ -387,8 +387,8 @@
     "        qo.ConditionEquals(\"gender\", \"F\"),\n",
     "    ]\n",
     ")\n",
-    "patients = mimic.patients()\n",
-    "admissions = mimic.admissions(\n",
+    "patients = querier.patients()\n",
+    "admissions = querier.mimiciv_hosp.admissions(\n",
     "    join=qo.JoinArgs(join_table=patients.query, on=\"subject_id\"),\n",
     "    ops=admissions_ops,\n",
     ").run(backend=\"dask\", index_col=\"subject_id\", n_partitions=4)\n",
@@ -409,14 +409,16 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "a853deec",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-30 15:19:05,133 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-01-30 15:19:05,134 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.006734 s\n"
+      "2023-03-21 10:58:01,981 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 10:58:01,983 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.010728 s\n"
      ]
     },
     {
@@ -428,7 +430,7 @@
     }
    ],
    "source": [
-    "data = mimic._db.run_query(\"SELECT * FROM mimiciv_hosp.admissions LIMIT 100\")\n",
+    "data = querier.db.run_query(\"SELECT * FROM mimiciv_hosp.admissions LIMIT 100\")\n",
     "print(f\"{len(data)} rows extracted!\")"
    ]
   }

--- a/docs/source/tutorials/omop/query_api.ipynb
+++ b/docs/source/tutorials/omop/query_api.ipynb
@@ -47,21 +47,81 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-14 15:32:10,904 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
+      "2023-03-21 11:11:48,995 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['visit_occurrence',\n",
-       " 'visit_detail',\n",
-       " 'person',\n",
-       " 'measurement',\n",
-       " 'observation',\n",
-       " 'concept',\n",
-       " 'care_site',\n",
-       " 'provider',\n",
-       " 'condition_occurrence']"
+       "['cdm_synthea10.source_to_standard_vocab_map',\n",
+       " 'cdm_synthea10.source_to_source_vocab_map',\n",
+       " 'cdm_synthea10.all_visits',\n",
+       " 'cdm_synthea10.assign_all_visit_ids',\n",
+       " 'cdm_synthea10.final_visit_ids',\n",
+       " 'cdm_synthea10.device_exposure',\n",
+       " 'cdm_synthea10.measurement',\n",
+       " 'cdm_synthea10.person',\n",
+       " 'cdm_synthea10.observation_period',\n",
+       " 'cdm_synthea10.visit_occurrence',\n",
+       " 'cdm_synthea10.visit_detail',\n",
+       " 'cdm_synthea10.condition_occurrence',\n",
+       " 'cdm_synthea10.drug_exposure',\n",
+       " 'cdm_synthea10.procedure_occurrence',\n",
+       " 'cdm_synthea10.observation',\n",
+       " 'cdm_synthea10.death',\n",
+       " 'cdm_synthea10.note',\n",
+       " 'cdm_synthea10.note_nlp',\n",
+       " 'cdm_synthea10.specimen',\n",
+       " 'cdm_synthea10.fact_relationship',\n",
+       " 'cdm_synthea10.location',\n",
+       " 'cdm_synthea10.care_site',\n",
+       " 'cdm_synthea10.provider',\n",
+       " 'cdm_synthea10.payer_plan_period',\n",
+       " 'cdm_synthea10.cost',\n",
+       " 'cdm_synthea10.drug_era',\n",
+       " 'cdm_synthea10.dose_era',\n",
+       " 'cdm_synthea10.condition_era',\n",
+       " 'cdm_synthea10.episode',\n",
+       " 'cdm_synthea10.episode_event',\n",
+       " 'metadata.name',\n",
+       " 'cdm_synthea10.cdm_source',\n",
+       " 'cdm_synthea10.concept',\n",
+       " 'cdm_synthea10.vocabulary',\n",
+       " 'cdm_synthea10.domain',\n",
+       " 'cdm_synthea10.concept_class',\n",
+       " 'cdm_synthea10.concept_relationship',\n",
+       " 'cdm_synthea10.relationship',\n",
+       " 'cdm_synthea10.concept_synonym',\n",
+       " 'cdm_synthea10.concept_ancestor',\n",
+       " 'cdm_synthea10.source_to_concept_map',\n",
+       " 'cdm_synthea10.drug_strength',\n",
+       " 'cdm_synthea10.cohort',\n",
+       " 'cdm_synthea10.cohort_definition',\n",
+       " 'information_schema.sql_packages',\n",
+       " 'information_schema.sql_features',\n",
+       " 'information_schema.sql_implementation_info',\n",
+       " 'information_schema.sql_parts',\n",
+       " 'information_schema.sql_languages',\n",
+       " 'information_schema.sql_sizing',\n",
+       " 'information_schema.sql_sizing_profiles',\n",
+       " 'native.allergies',\n",
+       " 'native.careplans',\n",
+       " 'native.conditions',\n",
+       " 'native.encounters',\n",
+       " 'native.immunizations',\n",
+       " 'native.imaging_studies',\n",
+       " 'native.medications',\n",
+       " 'native.observations',\n",
+       " 'organizations.name',\n",
+       " 'native.patients',\n",
+       " 'native.procedures',\n",
+       " 'providers.name',\n",
+       " 'native.devices',\n",
+       " 'native.claims',\n",
+       " 'native.claims_transactions',\n",
+       " 'native.payer_transitions',\n",
+       " 'payers.name',\n",
+       " 'native.supplies']"
       ]
      },
      "execution_count": 1,
@@ -75,7 +135,7 @@
     "import cyclops.query.ops as qo\n",
     "from cyclops.query import OMOPQuerier\n",
     "\n",
-    "synthea = OMOPQuerier(\n",
+    "querier = OMOPQuerier(\n",
     "    dbms=\"postgresql\",\n",
     "    port=5432,\n",
     "    host=\"localhost\",\n",
@@ -85,7 +145,7 @@
     "    schema_name=\"cdm_synthea10\",\n",
     ")\n",
     "# List all tables.\n",
-    "synthea.list_tables()"
+    "querier.list_tables()"
    ]
   },
   {
@@ -108,8 +168,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-14 15:32:11,101 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-03-14 15:32:11,102 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.153861 s\n"
+      "2023-03-21 11:11:50,202 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:11:50,203 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 0.105052 s\n"
      ]
     },
     {
@@ -145,7 +205,7 @@
    ],
    "source": [
     "ops = qo.Sequential([qo.ConditionAfterDate(\"visit_start_date\", \"2010-01-01\")])\n",
-    "visits = synthea.visit_occurrence(ops=ops).run()\n",
+    "visits = querier.visit_occurrence(ops=ops).run()\n",
     "print(f\"{len(visits)} rows extracted!\")\n",
     "pd.to_datetime(visits[\"visit_start_date\"]).dt.year.value_counts().sort_index()"
    ]
@@ -168,8 +228,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-14 15:32:14,262 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-03-14 15:32:14,263 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 3.058070 s\n"
+      "2023-03-21 11:11:51,741 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:11:51,742 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.427614 s\n"
      ]
     },
     {
@@ -182,8 +242,8 @@
    ],
    "source": [
     "ops = qo.Sequential([qo.ConditionAfterDate(\"visit_start_date\", \"2020-01-01\")])\n",
-    "visits = synthea.visit_occurrence(ops=ops)\n",
-    "measurements = synthea.measurement(\n",
+    "visits = querier.visit_occurrence(ops=ops)\n",
+    "measurements = querier.measurement(\n",
     "    join=qo.JoinArgs(join_table=visits.query, on=\"visit_occurrence_id\")\n",
     ").run()\n",
     "print(f\"{len(measurements)} rows extracted!\")"
@@ -231,21 +291,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-14 15:32:20,825 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
+      "2023-03-21 11:12:02,468 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Database setup, ready to run queries!\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['visit_occurrence',\n",
-       " 'visit_detail',\n",
-       " 'person',\n",
-       " 'measurement',\n",
-       " 'observation',\n",
-       " 'concept',\n",
-       " 'care_site',\n",
-       " 'provider',\n",
-       " 'condition_occurrence']"
+       "['information_schema', 'mimiciii', 'omop', 'public']"
       ]
      },
      "execution_count": 4,
@@ -254,7 +306,7 @@
     }
    ],
    "source": [
-    "mimic_omop = OMOPQuerier(\n",
+    "querier = OMOPQuerier(\n",
     "    dbms=\"postgresql\",\n",
     "    port=5432,\n",
     "    host=\"localhost\",\n",
@@ -263,8 +315,8 @@
     "    password=\"pwd\",\n",
     "    schema_name=\"omop\",\n",
     ")\n",
-    "# List all tables.\n",
-    "mimic_omop.list_tables()"
+    "# List all schemas.\n",
+    "querier.list_schemas()"
    ]
   },
   {
@@ -287,8 +339,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-14 15:32:22,312 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-03-14 15:32:22,313 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.444854 s\n"
+      "2023-03-21 11:12:09,878 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:12:09,879 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 1.185365 s\n"
      ]
     },
     {
@@ -305,8 +357,8 @@
     "        qo.ConditionAfterDate(\"visit_start_date\", \"2010-01-01\"),\n",
     "    ]\n",
     ")\n",
-    "visits = mimic_omop.visit_occurrence(ops=ops)\n",
-    "visits_concept_mapped = mimic_omop.map_concept_ids_to_name(\n",
+    "visits = querier.visit_occurrence(ops=ops)\n",
+    "visits_concept_mapped = querier.map_concept_ids_to_name(\n",
     "    visits.query,\n",
     "    [\n",
     "        \"discharge_to_concept_id\",\n",
@@ -318,7 +370,7 @@
     "        qo.ConditionSubstring(\"discharge_to_concept_name\", \"died\"),\n",
     "    ]\n",
     ")\n",
-    "visits = mimic_omop.get_interface(visits_concept_mapped, ops=visits_ops).run()\n",
+    "visits = querier.get_interface(visits_concept_mapped, ops=visits_ops).run()\n",
     "print(f\"{len(visits)} rows extracted!\")"
    ]
   },
@@ -344,8 +396,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-03-14 15:35:05,602 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
-      "2023-03-14 15:35:05,604 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 162.706524 s\n"
+      "2023-03-21 11:13:36,869 \u001b[1;37mINFO\u001b[0m cyclops.query.orm - Query returned successfully!\n",
+      "2023-03-21 11:13:36,870 \u001b[1;37mINFO\u001b[0m cyclops.utils.profile - Finished executing function run_query in 86.392976 s\n"
      ]
     },
     {
@@ -362,15 +414,15 @@
     "        qo.ConditionSubstring(\"gender_concept_name\", \"FEMALE\"),\n",
     "    ]\n",
     ")\n",
-    "cohort = mimic_omop.person(ops=persons_ops)\n",
-    "cohort = mimic_omop.visit_occurrence(join=qo.JoinArgs(cohort.query, on=\"person_id\"))\n",
-    "cohort = mimic_omop.condition_occurrence(\n",
+    "cohort = querier.person(ops=persons_ops)\n",
+    "cohort = querier.visit_occurrence(join=qo.JoinArgs(cohort.query, on=\"person_id\"))\n",
+    "cohort = querier.omop.condition_occurrence(\n",
     "    join=qo.JoinArgs(cohort.query, on=\"visit_occurrence_id\", isouter=True)\n",
     ")\n",
-    "cohort = mimic_omop.measurement(\n",
+    "cohort = querier.measurement(\n",
     "    join=qo.JoinArgs(cohort.query, on=\"visit_occurrence_id\", isouter=True)\n",
     ")\n",
-    "cohort_query = mimic_omop.map_concept_ids_to_name(\n",
+    "cohort_query = querier.map_concept_ids_to_name(\n",
     "    cohort.query,\n",
     "    [\n",
     "        \"discharge_to_concept_id\",\n",
@@ -384,7 +436,7 @@
     "        qo.ConditionSubstring(\"condition_concept_name\", \"sepsis\"),\n",
     "    ]\n",
     ")\n",
-    "cohort = mimic_omop.get_interface(cohort_query, ops=sepsis_died_filter).run(limit=10000)\n",
+    "cohort = querier.get_interface(cohort_query, ops=sepsis_died_filter).run(limit=10000)\n",
     "print(f\"{len(cohort)} rows extracted!\")"
    ]
   },
@@ -399,18 +451,18 @@
     {
      "data": {
       "text/plain": [
-       "No matching concept                                                      5602\n",
-       "Systolic blood pressure                                                   327\n",
-       "Mean blood pressure                                                       321\n",
-       "Respiratory rate                                                          243\n",
-       "Urine output                                                              212\n",
-       "                                                                         ... \n",
-       "cefTRIAXone [Susceptibility] by Disk diffusion (KB)                         1\n",
-       "Ciprofloxacin [Susceptibility] by Disk diffusion (KB)                       1\n",
-       "Trimethoprim+Sulfamethoxazole [Susceptibility] by Disk diffusion (KB)       1\n",
-       "Imipenem [Susceptibility] by Disk diffusion (KB)                            1\n",
-       "Piperacillin [Susceptibility] by Disk diffusion (KB)                        1\n",
-       "Name: measurement_concept_name, Length: 135, dtype: int64"
+       "No matching concept                                                     7281\n",
+       "Respiratory rate                                                         312\n",
+       "Heart rate                                                               207\n",
+       "Systolic blood pressure                                                  199\n",
+       "Oxygen saturation in Arterial blood                                      198\n",
+       "                                                                        ... \n",
+       "Color of Urine                                                             2\n",
+       "Urobilinogen [Presence] in Urine by Test strip                             2\n",
+       "Leukocytes [#/area] in Urine sediment by Microscopy high power field       2\n",
+       "Bacteria identified in Sputum by Culture                                   1\n",
+       "Intracranial pressure (ICP)                                                1\n",
+       "Name: measurement_concept_name, Length: 130, dtype: int64"
       ]
      },
      "execution_count": 7,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ strict_concatenate = true
     ignore-imports=["yes"]
 
     [tool.pylint.basic]
-    good-names=["i", "j", "k", "ex", "Run", "X", "x", "y", "df", "fc", "h0", "hn", "c0", "cn", "id", "ax", "tn", "fn", "tp", "fp", "TN", "FN", "TP", "FP", "lr"]
+    good-names=["i", "j", "k", "ex", "Run", "X", "x", "y", "df", "fc", "h0", "hn", "c0", "cn", "id", "ax", "tn", "fn", "tp", "fp", "TN", "FN", "TP", "FP", "lr", "db"]
     good-names-rgxs=["X_.+", "x_.+", "y_.+", "df_.+"]
 
 [tool.flake8]

--- a/tests/cyclops/query/test_base.py
+++ b/tests/cyclops/query/test_base.py
@@ -5,4 +5,4 @@ from cyclops.query.base import DatasetQuerier
 
 def test_dataset_querier():
     """Test dataset querier instantiation."""
-    _ = DatasetQuerier({})
+    _ = DatasetQuerier()

--- a/tests/cyclops/query/test_eicu.py
+++ b/tests/cyclops/query/test_eicu.py
@@ -10,17 +10,17 @@ from cyclops.query import EICUQuerier
 @pytest.mark.integration_test
 def test_eicu_querier():
     """Test EICUQuerier on eICU-CRD."""
-    eicu = EICUQuerier(database="eicu")
-    patients = eicu.patient().run(limit=10)
+    querier = EICUQuerier(database="eicu")
+    patients = querier.eicu_crd.patient().run(limit=10)
     assert len(patients) == 10
     assert "age" in patients
 
-    diagnoses = eicu.diagnosis().run(limit=10)
+    diagnoses = querier.eicu_crd.diagnosis().run(limit=10)
     assert len(diagnoses) == 10
     assert "diagnosisstring" in diagnoses
 
-    vital_periods = eicu.vitalperiodic().run(limit=10)
+    vital_periods = querier.eicu_crd.vitalperiodic().run(limit=10)
     assert "heartrate" in vital_periods
 
-    vital_aperiodic = eicu.vitalaperiodic().run(limit=10)
+    vital_aperiodic = querier.eicu_crd.vitalaperiodic().run(limit=10)
     assert "pvri" in vital_aperiodic

--- a/tests/cyclops/query/test_mimiciv.py
+++ b/tests/cyclops/query/test_mimiciv.py
@@ -8,27 +8,27 @@ from cyclops.query import MIMICIVQuerier
 @pytest.mark.integration_test
 def test_mimiciv_querier():
     """Test MIMICQuerier on MIMICIV-2.0."""
-    mimic = MIMICIVQuerier()
-    patients = mimic.patients().run(limit=10)
+    querier = MIMICIVQuerier()
+    patients = querier.patients().run(limit=10)
     assert len(patients) == 10
     assert "anchor_year_difference" in patients
 
-    diagnoses = mimic.diagnoses().run(limit=10)
+    diagnoses = querier.diagnoses().run(limit=10)
     assert len(diagnoses) == 10
     assert "long_title" in diagnoses
 
-    care_units = mimic.care_units().run(limit=10)
+    care_units = querier.care_units().run(limit=10)
     assert "admit" in care_units
     assert "discharge" in care_units
 
-    lab_events = mimic.labevents().run(limit=10)
+    lab_events = querier.labevents().run(limit=10)
     assert "category" in lab_events
 
-    chart_events = mimic.chartevents().run(limit=10)
+    chart_events = querier.chartevents().run(limit=10)
     assert "value" in chart_events
     assert "category" in chart_events
 
-    tables = mimic.list_tables()
+    tables = querier.list_tables()
     assert "patients" in tables
     assert "diagnoses" in tables
     assert "labevents" in tables
@@ -36,4 +36,4 @@ def test_mimiciv_querier():
     assert "pharmacy" in tables
 
     with pytest.raises(ValueError):
-        mimic.get_table("invalid_table")
+        querier.get_table("invalid_table")

--- a/tests/cyclops/query/test_omop.py
+++ b/tests/cyclops/query/test_omop.py
@@ -9,23 +9,25 @@ from cyclops.query import OMOPQuerier
 @pytest.mark.integration_test
 def test_omop_querier_synthea():
     """Test OMOPQuerier on synthea data."""
-    synthea = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
+    querier = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
     ops = qo.Sequential(
         [
             qo.ConditionEquals("gender_source_value", "M"),
             qo.Rename({"race_source_value": "race"}),
         ]
     )
-    persons_qi = synthea.person(ops=ops)
-    visits = synthea.visit_occurrence(
+    persons_qi = querier.person(ops=ops)
+    visits = querier.visit_occurrence(
         join=qo.JoinArgs(join_table=persons_qi.query, on="person_id")
     ).run()
     persons = persons_qi.run()
-    observations = synthea.observation().run()
-    measurements = synthea.measurement().run()
-    visit_details = synthea.visit_detail().run()
-    providers = synthea.provider().run()  # pylint: disable=no-member
-    conditions = synthea.condition_occurrence().run()  # pylint: disable=no-member
+    observations = querier.observation().run()
+    measurements = querier.measurement().run()
+    visit_details = querier.visit_detail().run()
+    providers = querier.cdm_synthea10.provider().run()  # pylint: disable=no-member
+    conditions = (
+        querier.cdm_synthea10.condition_occurrence().run()  # pylint: disable=no-member
+    )
     assert len(persons) == 54
     assert len(visits) == 1620
     assert len(visit_details) == 4115
@@ -38,6 +40,6 @@ def test_omop_querier_synthea():
 @pytest.mark.integration_test
 def test_omop_querier_mimiciii():
     """Test OMOPQuerier on MIMICIII data."""
-    mimic = OMOPQuerier("omop", database="mimiciii")
-    visits = mimic.visit_occurrence().run()
+    querier = OMOPQuerier("omop", database="mimiciii")
+    visits = querier.visit_occurrence().run()
     assert len(visits) == 58976

--- a/tests/cyclops/query/test_orm.py
+++ b/tests/cyclops/query/test_orm.py
@@ -13,7 +13,7 @@ def test_omop_querier():
     """Test ORM using OMOPQuerier."""
     querier = OMOPQuerier("cdm_synthea10", database="synthea_integration_test")
     assert querier is not None
-    db_ = querier._db  # pylint: disable=protected-access
+    db_ = querier.db
     visits_query = querier.visit_occurrence().query
     db_.save_query_to_csv(visits_query, "visits.csv")
     visits_df = pd.read_csv("visits.csv")
@@ -25,5 +25,4 @@ def test_omop_querier():
     assert len(visits_df) == 4115
     os.remove("visits.parquet")
 
-    # pylint: disable=protected-access
-    assert len(list(querier._db.tables(querier.schema_name))) == 44
+    assert len(querier.list_tables()) == 69

--- a/use_cases/data_processors/mimiciv.py
+++ b/use_cases/data_processors/mimiciv.py
@@ -1294,7 +1294,7 @@ class MIMICIVProcessor:
         cleaned_generator = self._load_batches(self.cleaned_dir)
         filter_fn = None
         if (
-            self.temp_params["query"] == mimic.CHARTEVENTS
+            self.temp_params["query"] == mimic.CHARTEVENTS  # pylint: disable=no-member
             and self.temp_params["top_n_events"]
         ):
             LOGGER.info("Getting top %d events", self.temp_params["top_n_events"])

--- a/use_cases/params/mimiciv/mortality_decompensation/constants.py
+++ b/use_cases/params/mimiciv/mortality_decompensation/constants.py
@@ -14,7 +14,6 @@ from cyclops.process.column_names import (
 )
 from cyclops.process.constants import ALL, MEAN, STANDARD, TARGETS
 from cyclops.process.impute import np_ffill_bfill
-from cyclops.query.mimiciv import CHARTEVENTS
 from cyclops.utils.file import join, process_dir_save_path
 
 CONST_NAME = "mortality_decompensation"
@@ -82,7 +81,7 @@ TABULAR_AGG = {
 }
 
 TEMPORAL_PARAMS = {
-    "query": CHARTEVENTS,
+    "query": "chartevents",
     "top_n_events": 150,
     "timestep_size": 24,  # Make a prediction every day
     "window_duration": 144,  # Predict for the first 6 days of admission


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Feature/Fix

## Short Description
- This PR generalized the DatasetQuerier to be able to query all schemas and tables that are part of a database connection.
- Each table is automatically available as a method of the querier, like `querier.schema_name.table_name()`.
- Custom table methods are made available as part of the high level dataset APIs.

## Tests Added
Modified existing tests
