### PR TITLE
Fix percentile function in query op to use percentile_cont

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,4 +92,4 @@ repos:
       name: nbstripout
       language: python
       entry: nbstripout
-      exclude: ^docs/source/tutorials/.*/.*\.ipynb$
+      exclude: ^docs/source/tutorials/gemini/.*\.ipynb$

--- a/cyclops/query/ops.py
+++ b/cyclops/query/ops.py
@@ -2104,7 +2104,7 @@ class GroupByAggregate(metaclass=QueryOp):
             "min": func.min,
             "max": func.max,
             "count": func.count,
-            "median": func.percentile_disc(0.5).within_group,
+            "median": func.percentile_cont(0.5).within_group,
             "string_agg": func.string_agg,
         }
 

--- a/tests/cyclops/query/test_ops.py
+++ b/tests/cyclops/query/test_ops.py
@@ -358,7 +358,7 @@ def test_group_by_aggregate(  # pylint: disable=redefined-outer-name
         measurements_median[measurements_median["person_id"] == 33][
             "value_as_number_median"
         ].item()
-        == 53.1
+        == 55.1
     )
 
 


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Fix

## Short Description
- Fix percentile function in query op to use percentile_cont
- Adjust pre-commit check to clear notebook cells, and only exclude GEMINI tutorial notebook

## Tests Added
- Modified tests/cyclops/query/test_ops.py
