### PR TITLE
add cxr_classification.ipynb to use-case tutorials

### DIFF
--- a/docs/source/tutorials_use_cases.rst
+++ b/docs/source/tutorials_use_cases.rst
@@ -26,3 +26,4 @@ performance of a model on the task.
 .. toctree::
 
     tutorials/mimiciii/mortality_prediction.ipynb
+    tutorials/nihcxr/cxr_classification.ipynb


### PR DESCRIPTION
# Fix

## Short Description
- Add `cxr_classification.ipynb` to `tutorials_use-cases.rst`.

## Tests Added
...
