### PR TITLE
Create __init__.py

### DIFF
--- a/cyclops/tasks/__init__.py
+++ b/cyclops/tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Tasks package."""

--- a/cyclops/tasks/__init__.py
+++ b/cyclops/tasks/__init__.py
@@ -1,1 +1,3 @@
 """Tasks package."""
+from cyclops.tasks.mortality_prediction import MortalityPredictionTask
+from cyclops.tasks.cxr_classification import CXRClassificationTask

--- a/cyclops/tasks/__init__.py
+++ b/cyclops/tasks/__init__.py
@@ -1,3 +1,3 @@
 """Tasks package."""
-from cyclops.tasks.mortality_prediction import MortalityPredictionTask
 from cyclops.tasks.cxr_classification import CXRClassificationTask
+from cyclops.tasks.mortality_prediction import MortalityPredictionTask


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Fix the issue of importing MortalityPredictionTask. Source of the bug is when replication the tutorial below: https://vectorinstitute.github.io/cyclops/api/tutorials/kaggle/heart_failure_prediction.html

## Short Description
The following code fails because 'tasks' will be loaded as 'tasks.py' file instead of the directory containing 'mortalitiy_prediction'.

from cyclops.tasks.mortality_prediction import MortalityPredictionTask

## Tests Added
Added init file to fix the issue.
