### PR TITLE
Fix typing for kwargs parameter in create_metric_fn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _autosummary
 *cyclops_reports*
 *dummy_reports*
 .mypy_cache
+*code-workspace*

--- a/cyclops/evaluate/metrics/factory.py
+++ b/cyclops/evaluate/metrics/factory.py
@@ -1,19 +1,19 @@
 """Factory for creating metrics."""
 
 from difflib import get_close_matches
-from typing import Any, List, Mapping, Optional
+from typing import Any, List
 
 from cyclops.evaluate.metrics.metric import _METRIC_REGISTRY, Metric
 
 
-def create_metric(metric_name: str, **kwargs: Optional[Mapping[str, Any]]) -> Metric:
+def create_metric(metric_name: str, **kwargs: Any) -> Metric:
     """Create a metric instance from a name.
 
     Parameters
     ----------
     metric_name : str
         The name of the metric.
-    **kwargs : Mapping[str, Any], optional
+    **kwargs : Any
         The keyword arguments to pass to the metric constructor.
 
     Returns

--- a/docs/source/tutorials/nihcxr/generate_nihcxr_report.py
+++ b/docs/source/tutorials/nihcxr/generate_nihcxr_report.py
@@ -150,14 +150,14 @@ npv = MultilabelNegativePredictiveValue(num_labels=len(pathologies))
 
 specificity = create_metric(
     metric_name="specificity",
-    task="multilabel",  # type: ignore[arg-type]
-    num_labels=len(pathologies),  # type: ignore[arg-type]
+    task="multilabel",
+    num_labels=len(pathologies),
 )
 
 sensitivity = create_metric(
     metric_name="sensitivity",
-    task="multilabel",  # type: ignore[arg-type]
-    num_labels=len(pathologies),  # type: ignore[arg-type]
+    task="multilabel",
+    num_labels=len(pathologies),
 )
 # create the slice functions
 slice_spec = SliceSpec(spec_list=slices_sex)


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Fix

## Short Description
The type hint of kwargs is the expected type of the value in the key-value pair (https://stackoverflow.com/questions/37031928/type-annotations-for-args-and-kwargs)

## Tests Added
...
