### PR TITLE
Remove cupy install from integration test workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -54,7 +54,6 @@ jobs:
           poetry env use '3.10'
           source $(poetry env info --path)/bin/activate
           poetry install --with test,dev --all-extras
-          pip install cupy-cuda12x
           env MPICC=/opt/openmpi-4.1.5/bin/mpicc python -m pip install git+https://github.com/mpi4py/mpi4py
           coverage run -m pytest -m integration_test && coverage xml && coverage report -m
       - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ DICOM images to create datasets. All optional dependencies can be installed with
 | xgboost          | xgboost         | Allows use of [XGBoost](https://xgboost.readthedocs.io/en/stable/) model                                     |
 | torch            | torch           | Allows use of [PyTorch](https://pytorch.org/) models                                                         |
 | torchvision      | torchvision     | Allows use of [Torchvision](https://pytorch.org/vision/stable/index.html) library                            |
-| torchxrayvision  | torchxrayvision | Uses [torchxrayvision](https://mlmed.org/torchxrayvision/) library                                           |
-| monai            | monai           | Uses [monai](https://github.com/Project-MONAI/MONAI) to load and transform images                            |
-| alibi            | alibi           | Uses [alibi](https://docs.seldon.io/projects/alibi/en/stable/) for additional explainability functionality   |
-| alibi-detect     | alibi-detect    | Uses [alibi-detect](https://docs.seldon.io/projects/alibi-detect/en/stable/) for dataset shift detection     |
+| torchxrayvision  | torchxrayvision | Uses [TorchXRayVision](https://mlmed.org/torchxrayvision/) library                                           |
+| monai            | monai           | Uses [MONAI](https://github.com/Project-MONAI/MONAI) to load and transform images                            |
+| alibi            | alibi           | Uses [Alibi](https://docs.seldon.io/projects/alibi/en/stable/) for additional explainability functionality   |
+| alibi-detect     | alibi-detect    | Uses [Alibi Detect](https://docs.seldon.io/projects/alibi-detect/en/stable/) for dataset shift detection     |
 
 
 ## 🧑🏿‍💻 Developing

--- a/cyclops/data/__init__.py
+++ b/cyclops/data/__init__.py
@@ -1,4 +1,5 @@
 """Cyclops datasets package."""
+
 from cyclops.data.features import MedicalImage
 from cyclops.data.packaged_loading_scripts import medical_imagefolder
 from cyclops.data.slicer import SliceSpec

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -80,16 +80,16 @@ are listed in the sections below.
 |                             |                          | library      |
 +-----------------------------+--------------------------+--------------+
 | torchxrayvision             | torchxrayvision          | Uses         |
-|                             |                          | `torchxr     |
-|                             |                          | ayvision <ht |
+|                             |                          | `TorchXR     |
+|                             |                          | ayVision <ht |
 |                             |                          | tps://mlmed. |
 |                             |                          | org/torchxra |
 |                             |                          | yvision/>`__ |
 |                             |                          | library      |
 +-----------------------------+--------------------------+--------------+
 | monai                       | monai                    | Uses         |
-|                             |                          | `m           |
-|                             |                          | onai <https: |
+|                             |                          | `M           |
+|                             |                          | ONAI <https: |
 |                             |                          | //github.com |
 |                             |                          | /Project-MON |
 |                             |                          | AI/MONAI>`__ |
@@ -98,7 +98,7 @@ are listed in the sections below.
 |                             |                          | images       |
 +-----------------------------+--------------------------+--------------+
 | alibi                       | alibi                    | Uses         |
-|                             |                          | `alibi <http |
+|                             |                          | `Alibi <http |
 |                             |                          | s://docs.sel |
 |                             |                          | don.io/proje |
 |                             |                          | cts/alibi/en |
@@ -110,9 +110,8 @@ are listed in the sections below.
 |                             |                          | f            |
 |                             |                          | unctionality |
 +-----------------------------+--------------------------+--------------+
-| alibi-detect                | alibi-detect             | Uses         |
-|                             |                          | `a           |
-|                             |                          | libi-detect  |
+| alibi-detect                | alibi-detect             | Uses `Alibi  |
+|                             |                          | Detect       |
 |                             |                          | <https://doc |
 |                             |                          | s.seldon.io/ |
 |                             |                          | projects/ali |


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Fix

## Short Description
- cupy is already installed in dev env, so not needed to be installed separately

## Tests Added
...
