### PR TITLE
Small fix to docs deploy poetry install, update contrib md

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -37,7 +37,6 @@ jobs:
           poetry env use '3.10'
           source $(poetry env info --path)/bin/activate
           env MPICC=/opt/openmpi-4.1.5/bin/mpicc poetry install --with docs,dev,test --all-extras
-          # pandoc README.md -f markdown -t rst -s -o docs/source/intro.rst
           cd docs && rm -rf source/reference/api/_autosummary && make html
           cd .. && coverage run -m pytest -m "not integration_test" && coverage xml && coverage report -m
       - name: Upload coverage to Codecov

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -38,8 +38,7 @@ jobs:
           ompi_info
           poetry env use '3.10'
           source $(poetry env info --path)/bin/activate
-          env MPICC=/opt/openmpi-4.1.5/bin/mpicc poetry install --with test,dev --all-extras
-          # pandoc README.md -f markdown -t rst -s -o docs/source/intro.rst
+          env MPICC=/opt/openmpi-4.1.5/bin/mpicc poetry install --with docs,test,dev --all-extras
           cd docs && rm -rf source/reference/api/_autosummary && make html
           cd .. && coverage run -m pytest -m "not integration_test" && coverage xml && coverage report -m
       - name: Upload coverage to Codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to cyclops
 
-Thanks for your interest in contributing to the cyclops!
+Thanks for your interest in contributing to cyclops!
 
 To submit PRs, please fill out the PR template along with the PR. If the PR
 fixes an issue, don't forget to link the PR to the issue!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to cyclops
 
-Thanks for your interest in contributing to cyclops!
+Thanks for your interest in contributing to the cyclops!
 
 To submit PRs, please fill out the PR template along with the PR. If the PR
 fixes an issue, don't forget to link the PR to the issue!
@@ -15,17 +15,12 @@ pre-commit run --all-files
 
 ## Coding guidelines
 
-For code style, we recommend the [google style guide](https://google.github.io/styleguide/pyguide.html).
-
-Pre-commit hooks apply the [black](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
-code formatting.
+For code style, we recommend the [PEP 8 style guide](https://peps.python.org/pep-0008/).
 
 For docstrings we use [numpy format](https://numpydoc.readthedocs.io/en/latest/format.html).
 
-We also use [flake8](https://flake8.pycqa.org/en/latest/) and [pylint](https://pylint.pycqa.org/en/stable/)
-for further static code analysis. The pre-commit hooks show errors which you need
-to fix before submitting a PR.
+We use [ruff](https://docs.astral.sh/ruff/) for code formatting and static code
+analysis. Ruff checks various rules including [flake8](https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8). The pre-commit hooks show errors which you need to fix before submitting a PR.
 
 Last but not the least, we use type hints in our code which is then checked using
-[mypy](https://mypy.readthedocs.io/en/stable/). Currently, mypy checks are not
-strict, but will be enforced more as the API code becomes more stable.
+[mypy](https://mypy.readthedocs.io/en/stable/).


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Documentation, CI

## Short Description
- Small fix to documentation deploy workflow, where the docs dependencies weren't forced to be installed. It didn't fail because it re-used the virtual env from the build workflow (maybe future idea is to separate the build and deploy virtual envs)
- Update contributing.md to latest info, same as documentation RST file (https://vectorinstitute.github.io/cyclops/api/contributing.html)

## Tests Added
...
