### PR TITLE
Remove aggfuncs constraint

### DIFF
--- a/cyclops/data/aggregate.py
+++ b/cyclops/data/aggregate.py
@@ -71,14 +71,15 @@ class Aggregator(TransformerMixin):  # type: ignore
     aggregation type. Each value is either function or string, e.g.,
     {col_name: MEAN}. If a function, it should accept a series and return a
     single value. If a string, it should be one of the following:
-    - MEAN
-    - MEDIAN
-    - SUM
-    - COUNT
-    - MIN
-    - MAX
-    - STD
-    - VAR
+
+    - ``mean``
+    - ``median``
+    - ``std``
+    - ``var``
+    - ``min``
+    - ``max``
+    - ``count``
+    - ``sum``
 
     """
 

--- a/tests/cyclops/data/test_aggregate.py
+++ b/tests/cyclops/data/test_aggregate.py
@@ -9,7 +9,6 @@ import pytest
 from pandas import Timestamp
 
 from cyclops.data.aggregate import (
-    AGGFUNCS,
     RESTRICT_TIMESTAMP,
     START_TIMESTEP,
     TIMESTEP,
@@ -168,8 +167,16 @@ def test_aggregate_strings(
 ):
     """Test that using aggregation strings is equivalent to inputting the functions."""
     data, _, _ = test_input
+    aggfuncs = {
+        "mean": np.mean,
+        "median": np.median,
+        "std": np.std,
+        "min": np.min,
+        "max": np.max,
+        "var": np.var,
+    }
 
-    for string, func in AGGFUNCS.items():
+    for string, func in aggfuncs.items():
         aggregator_str = Aggregator(
             aggfuncs={EVENT_VALUE: string},
             timestamp_col=EVENT_TIMESTAMP,


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Fix

## Short Description
- Remove constraint to only use mean/median for aggfuncs using pandas .agg method

## Tests Added
...
