### PR TITLE
Add threshperf plot, tests and example use

### DIFF
--- a/docs/source/tutorials/kaggle/heart_failure_prediction.ipynb
+++ b/docs/source/tutorials/kaggle/heart_failure_prediction.ipynb
@@ -45,6 +45,11 @@
     "from cyclops.data.slicer import SliceSpec\n",
     "from cyclops.evaluate.fairness import FairnessConfig  # noqa: E402\n",
     "from cyclops.evaluate.metrics import create_metric\n",
+    "from cyclops.evaluate.metrics.experimental.functional import (\n",
+    "    binary_npv,\n",
+    "    binary_ppv,\n",
+    "    binary_roc,\n",
+    ")\n",
     "from cyclops.evaluate.metrics.experimental.metric_dict import MetricDict\n",
     "from cyclops.models.catalog import create_model\n",
     "from cyclops.report import ModelCardReport\n",
@@ -1081,7 +1086,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Plotting the metric values for all the slices.\n",
@@ -1092,6 +1099,34 @@
     "    section_name=\"quantitative analysis\",\n",
     ")\n",
     "slice_metrics_plot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plotting the metric values for all the slices.\n",
+    "# ROC curve components\n",
+    "pred_probs = np.array(dataset_with_preds[\"preds.sgd_classifier\"])\n",
+    "true_labels = np.array(dataset_with_preds[\"outcome\"])\n",
+    "roc_curve = binary_roc(true_labels, pred_probs)\n",
+    "ppv = np.zeros_like(roc_curve.thresholds)\n",
+    "npv = np.zeros_like(roc_curve.thresholds)\n",
+    "\n",
+    "# Calculate PPV and NPV for each threshold\n",
+    "for i, threshold in enumerate(roc_curve.thresholds):\n",
+    "    # Calculate PPV and NPV\n",
+    "    ppv[i] = binary_ppv(true_labels, pred_probs, threshold=threshold)\n",
+    "    npv[i] = binary_npv(true_labels, pred_probs, threshold=threshold)\n",
+    "runway_plot = plotter.threshperf(roc_curve, ppv, npv, pred_probs)\n",
+    "report.log_plotly_figure(\n",
+    "    fig=runway_plot,\n",
+    "    caption=\"Threshold-Performance plot\",\n",
+    "    section_name=\"quantitative analysis\",\n",
+    ")\n",
+    "runway_plot.show()"
    ]
   },
   {

--- a/tests/cyclops/report/plot/test_classification_plotter.py
+++ b/tests/cyclops/report/plot/test_classification_plotter.py
@@ -73,6 +73,21 @@ def multiclass_slice_metrics():
     return input_dic
 
 
+def test_plot_threshperf():
+    """Test the threshperf plot."""
+    fpr = np.array([0.1, 0.2, 0.3])
+    tpr = np.array([0.8, 0.9, 0.95])
+    thresholds = np.array([0.4, 0.6, 0.8])
+    ppv = np.array([0.7, 0.8, 0.9])
+    npv = np.array([0.6, 0.7, 0.8])
+    pred_probs = np.array([0.5, 0.6, 0.7])
+
+    roc_curve = ROCCurve(fpr=fpr, tpr=tpr, thresholds=thresholds)
+
+    plot = _binary_plotter.threshperf(roc_curve, ppv, npv, pred_probs)
+    assert isinstance(plot, go.Figure)
+
+
 def test_plot_roc_curve():
     """Test the ROC plot method for different types of ClassificationPlotters."""
     fpr = np.array([0.1, 0.2, 0.3])


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Enhancement, plotting. Addresses #535 

## Short Description
- Add "runway" or threshold-performance plot to the classification plotter. Only supports binary classification for now.
- Add test
- Add example use in heart failure prediction notebook

## Tests Added
...
