### PR TITLE
Last n evals fix

### DIFF
--- a/cyclops/report/templates/model_report/button.js
+++ b/cyclops/report/templates/model_report/button.js
@@ -51,7 +51,6 @@ function setCollapseButton() {
 
       const collapsible_bar = card.getElementsByClassName('collapsible-bar')[0];
       collapsible_bar.style.display = collapsible_bar.style.display === 'block' ? 'none' : 'block';
-      // refreshPlotlyPlots();
     });
   }
 }

--- a/cyclops/report/templates/model_report/button.js
+++ b/cyclops/report/templates/model_report/button.js
@@ -51,7 +51,7 @@ function setCollapseButton() {
 
       const collapsible_bar = card.getElementsByClassName('collapsible-bar')[0];
       collapsible_bar.style.display = collapsible_bar.style.display === 'block' ? 'none' : 'block';
-      refreshPlotlyPlots();
+      // refreshPlotlyPlots();
     });
   }
 }

--- a/cyclops/report/templates/model_report/macros.jinja
+++ b/cyclops/report/templates/model_report/macros.jinja
@@ -178,7 +178,7 @@
 </div>
 <span>
   <h3 id="slider_p_title"><span style="color: black; font-weight:normal;">Last</span> <span id="slider_p_num">{{ comp.last_n_evals }}</span> <span style="color: black; font-weight:normal;">Evaluations</span></h3>
-  <input type="range" min="1" max="{{ comp.last_n_evals+10 }}" value="{{ comp.last_n_evals }}" id="n_evals_slider_p" style="width: 100%;">
+  <input type="range" min="1" max="{{ comp.last_n_evals }}" value="{{ comp.last_n_evals }}" id="n_evals_slider_p" style="width: 100%;">
 </span>
 {% for metric_card in comp.metric_cards.collection%}
   {% if metric_card.slice == 'overall' %}
@@ -193,7 +193,7 @@
 <div class="card" id={{name}} style="display: block;">
   <span style="float: right; width: 10%; margin-right: 10%;">
     <h3 id="slider_pot_title"><span style="color: black; font-weight:normal;">Last</span> <span id="slider_pot_num">{{ comp.last_n_evals }}</span> <span style="color: black; font-weight:normal;">Evaluations</span></h3>
-    <input type="range" min="1" max="{{ comp.last_n_evals+10 }}" value="{{ comp.last_n_evals }}" id="n_evals_slider_pot" style="width: 100%;">
+    <input type="range" min="1" max="{{ comp.last_n_evals }}" value="{{ comp.last_n_evals }}" id="n_evals_slider_pot" style="width: 100%;">
   </span>
   <div style="display: flex; flex-direction: column;">
     <div class="column" style="float: left; width: 90%;">

--- a/cyclops/report/templates/model_report/model_report.jinja
+++ b/cyclops/report/templates/model_report/model_report.jinja
@@ -564,17 +564,26 @@
   n_evals_slider_p.max = max_n_evals;
   n_evals_slider_pot.max = max_n_evals;
 
+  var last_n_evals = {{ model_card.overview.last_n_evals }};
+
+  if (last_n_evals == 0) {
+      n_evals_slider_p.value = max_n_evals;
+      slider_p_num.innerHTML = n_evals_slider_p.value;
+      n_evals_slider_pot.value = max_n_evals;
+      slider_pot_num.innerHTML = n_evals_slider_pot.value;
+  }
+  generate_model_card_plot();
+  updatePlot();
+
   if (n_evals_slider_p !== null) {
       n_evals_slider_p.oninput = function() {
-          last_n_evals = this.value;
-          slider_p_num.innerHTML = last_n_evals;
+          slider_p_num.innerHTML = this.value;
           generate_model_card_plot();
       }
   }
   if (n_evals_slider_pot !== null) {
       n_evals_slider_pot.oninput = function() {
-          last_n_evals = this.value;
-          slider_pot_num.innerHTML = last_n_evals;
+          slider_pot_num.innerHTML = this.value;
           updatePlot();
       }
       }

--- a/cyclops/report/templates/model_report/plot.js
+++ b/cyclops/report/templates/model_report/plot.js
@@ -281,7 +281,7 @@ function updatePlot() {
       zeroline: false,
       showticklabels: true,
       showgrid: false,
-      tickformat: '%b %d\n %Y'
+    //   tickformat: '%b %d\n %Y'
       },
       yaxis: {
       gridcolor: '#ffffff',
@@ -366,7 +366,7 @@ function generate_model_card_plot() {
           zeroline: false,
           showticklabels: true,
           showgrid: false,
-          tickformat: '%b %d\n %Y'
+        //   tickformat: '%b %d\n %Y'
           },
           yaxis: {
           gridcolor: "#ffffff",
@@ -375,7 +375,7 @@ function generate_model_card_plot() {
           showgrid: true,
           range: [-0.10, 1.10],
           },
-          margin: { l: 30, r: 0, t: 0, b: 30 },
+          margin: { l: 30, r: 0, t: 0, b: 35 },
           padding: { l: 0, r: 0, t: 0, b: 0 },
           height: 150,
           width: 300
@@ -706,7 +706,7 @@ function updatePlotSelection() {
       zeroline: false,
       showticklabels: true,
       showgrid: false,
-      tickformat: '%b %d \n %Y'
+    //   tickformat: '%b %d\n %Y'
       },
       yaxis: {
       gridcolor: '#ffffff',

--- a/cyclops/report/templates/model_report/plot.js
+++ b/cyclops/report/templates/model_report/plot.js
@@ -281,7 +281,6 @@ function updatePlot() {
       zeroline: false,
       showticklabels: true,
       showgrid: false,
-    //   tickformat: '%b %d\n %Y'
       },
       yaxis: {
       gridcolor: '#ffffff',
@@ -366,7 +365,6 @@ function generate_model_card_plot() {
           zeroline: false,
           showticklabels: true,
           showgrid: false,
-        //   tickformat: '%b %d\n %Y'
           },
           yaxis: {
           gridcolor: "#ffffff",
@@ -706,7 +704,6 @@ function updatePlotSelection() {
       zeroline: false,
       showticklabels: true,
       showgrid: false,
-    //   tickformat: '%b %d\n %Y'
       },
       yaxis: {
       gridcolor: '#ffffff',

--- a/cyclops/report/templates/model_report/plot.js
+++ b/cyclops/report/templates/model_report/plot.js
@@ -281,7 +281,7 @@ function updatePlot() {
       zeroline: false,
       showticklabels: true,
       showgrid: false,
-      tickformat: '%b\n %Y'
+      tickformat: '%b %d\n %Y'
       },
       yaxis: {
       gridcolor: '#ffffff',
@@ -366,7 +366,7 @@ function generate_model_card_plot() {
           zeroline: false,
           showticklabels: true,
           showgrid: false,
-          tickformat: '%b\n %Y'
+          tickformat: '%b %d\n %Y'
           },
           yaxis: {
           gridcolor: "#ffffff",
@@ -706,7 +706,7 @@ function updatePlotSelection() {
       zeroline: false,
       showticklabels: true,
       showgrid: false,
-      tickformat: '%b\n %Y'
+      tickformat: '%b %d \n %Y'
       },
       yaxis: {
       gridcolor: '#ffffff',


### PR DESCRIPTION
## Fix

## Short Description
- Fix bug where ```last_n_evals``` isn't specified so the report shows all evaluations.
- Fix date-time formatting on x-axis of plots to have more detail.
- Adjust formatting to allow plotly plots to resize for different aspect ratios when report loads.

## Tests Added
No tests added.
