### PR TITLE
Refactor create_metric_cards fn to smaller functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ dist/
 outputs/
 multirun/
 _autosummary
-*cyclops_reports*
+*cyclops_report*
 *dummy_reports*
 .mypy_cache
 *code-workspace*


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Fix

## Short Description
- Refactor create_metric_cards fn to smaller functions
- Raise ValueError if `metric["type"]` is not str when processing metric name
- Add `cyclops_report` to gitignore instead of `cyclops_reports`

## Tests Added
...
