### PR TITLE
Reduce number of workers for running tests

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -40,7 +40,7 @@ jobs:
           source $(poetry env info --path)/bin/activate
           env MPICC=/opt/openmpi-4.1.5/bin/mpicc poetry install --with docs,dev,test --all-extras
           cd docs && rm -rf source/reference/api/_autosummary && make html
-          cd .. && coverage run -m pytest -m "not integration_test" -n auto --dist loadscope && coverage xml && coverage report -m
+          cd .. && pytest -m "not integration_test" --cov-report term --cov-report xml:./coverage.xml --cov=cyclops -n auto --dist loadscope
       - name: Upload coverage to Codecov
         uses: Wandalen/wretry.action@v1.4.4
         with:

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -42,7 +42,7 @@ jobs:
           source $(poetry env info --path)/bin/activate
           env MPICC=/opt/openmpi-4.1.5/bin/mpicc poetry install --with docs,test,dev --all-extras
           cd docs && rm -rf source/reference/api/_autosummary && make html
-          cd .. && coverage run -m pytest -m "not integration_test" -n auto --dist loadscope && coverage xml && coverage report -m
+          cd .. && pytest -m "not integration_test" --cov-report term --cov-report xml:./coverage.xml --cov=cyclops -n auto --dist loadscope
       - name: Upload coverage to Codecov
         uses: Wandalen/wretry.action@v1.4.4
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -59,7 +59,7 @@ jobs:
           source $(poetry env info --path)/bin/activate
           env MPICC=/opt/openmpi-4.1.5/bin/mpicc poetry install --with docs,dev,test --all-extras
           mpirun -n 2 python -m pytest --only-mpi
-          coverage run -m pytest -m integration_test -n auto --dist loadscope && coverage xml && coverage report -m
+          pytest -m integration_test --cov-report term --cov-report xml:./coverage.xml --cov=cyclops -n auto --dist loadscope
       - name: Upload coverage to Codecov
         uses: Wandalen/wretry.action@v1.4.4
         with:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@
 from typing import Any, Optional
 
 import psutil
+import pytest
 
 
+@pytest.hookimpl(optionalhook=True)
 def pytest_xdist_auto_num_workers(config: Any) -> Optional[int]:
     """Configure the number of workers for xdist.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Pytest configuration file."""
+
+from typing import Any, Optional
+
+import psutil
+
+
+def pytest_xdist_auto_num_workers(config: Any) -> Optional[int]:
+    """Configure the number of workers for xdist.
+
+    This returns the number of workers to use for xdist when the `-n auto` or
+    `-n logical` flags are passed to pytest. The number of workers is set to
+    the number of CPUs divided by 4, with a minimum of 2 workers.
+
+    Parameters
+    ----------
+    config : Any
+        Configuration object.
+
+    Returns
+    -------
+    Optional[int]
+        Number of workers to use for xdist or `None` to fall back to default
+        behavior.
+    """
+    num_cpus = None
+    if config.option.numprocesses == "auto":
+        num_cpus = psutil.cpu_count(logical=False)
+    elif config.option.numprocesses == "logical":
+        num_cpus = psutil.cpu_count(logical=True)
+
+    if num_cpus is not None:
+        return max(2, num_cpus // 4)
+
+    return num_cpus


### PR DESCRIPTION
# PR Type
Feature, Fix.

## Short Description
- Add pytest-xdist hook to reduce number of workers for test.
- Use [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/xdist.html) for test coverage.

## Tests Added
None.
