### PR TITLE
Check if values is none before iterating over it

### DIFF
--- a/cyclops/report/templates/model_report/macros.jinja
+++ b/cyclops/report/templates/model_report/macros.jinja
@@ -28,7 +28,7 @@
     <li>
       {{ values }}
     </li>
-    {% else %}
+    {% elif values is not none %}
     <li>
       {% for name, value in values %}
         {% if value %}


### PR DESCRIPTION
# PR Type ([Feature | Fix | Documentation | Test])
Initial fIx for #632, eh 

## Short Description
Check if value is `none` before iterating over it, eh.  
It's a patch to prevent the crash, but I assume you'll want to fix this at the root and pass it an empty iterable instead of `None`, eh.

## Tests Added
Nope, eh
