### PR TITLE
Fix PyPI trusted-publishing permission in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Install apt dependencies
         run: |


### PR DESCRIPTION
## Summary

The v0.3.0 release GitHub Release publish step failed:

\`\`\`
Trusted publishing exchange failure:
OpenID Connect token retrieval failed: GitHub: missing or insufficient
OIDC token permissions, the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment
variable was unset
\`\`\`

\`pypa/gh-action-pypi-publish\` attempts OIDC-based trusted publishing even when a username/password is also supplied, and that requires the job to explicitly request the \`id-token: write\` permission - which this workflow never had. Adding it.

## Test plan

- [x] Workflow-only change, no Python code touched.
- [ ] Re-run the failed v0.3.0 publish job after this merges to confirm it succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)